### PR TITLE
Add php line formatter

### DIFF
--- a/Datatable/Data/DatatableData.php
+++ b/Datatable/Data/DatatableData.php
@@ -80,6 +80,10 @@ class DatatableData implements DatatableDataInterface
      */
     protected $joins;
 
+    /**
+     * @var callable
+     */
+    protected $lineFormatter;
 
     //-------------------------------------------------
     // Ctor.
@@ -265,6 +269,19 @@ class DatatableData implements DatatableDataInterface
         return $this;
     }
 
+    /**
+     * Set the line formatter function
+     * 
+     * @var callable
+     * @return $this;
+     */
+    public function setLineFormatter(callable $lineFormatter = null)
+    {
+        $this->lineFormatter = $lineFormatter;
+
+        return $this;        
+    }
+
 
     //-------------------------------------------------
     // DatatableDataInterface
@@ -282,6 +299,10 @@ class DatatableData implements DatatableDataInterface
         $output = array("data" => array());
 
         foreach ($fresults as $item) {
+            if (is_callable($this->lineFormatter)) {
+                $callable = $this->lineFormatter;
+                $item = call_user_func($callable, $item);
+            }
             $output["data"][] = $item;
         }
 

--- a/Datatable/Data/DatatableDataManager.php
+++ b/Datatable/Data/DatatableDataManager.php
@@ -113,6 +113,7 @@ class DatatableDataManager
 
         $datatableQuery = new DatatableQuery($params, $metadata, $em);
         $datatableData = new DatatableData($params, $metadata, $em, $this->serializer, $datatableQuery);
+        $datatableData->setLineFormatter($datatableView->getLineFormatter());
 
         return $datatableData->getResponse();
     }

--- a/Datatable/View/AbstractDatatableView.php
+++ b/Datatable/View/AbstractDatatableView.php
@@ -288,6 +288,16 @@ abstract class AbstractDatatableView implements DatatableViewInterface
     //-------------------------------------------------
 
     /**
+     * Get Line transformer
+     *
+     * @return callable
+     */
+    public function getLineFormatter()
+    {
+        return null;
+    }
+
+    /**
      * Set Templating.
      *
      * @param TwigEngine $templating

--- a/Datatable/View/DatatableViewInterface.php
+++ b/Datatable/View/DatatableViewInterface.php
@@ -60,4 +60,11 @@ interface DatatableViewInterface
      * @return string
      */
     public function getName();
+
+    /**
+     * Returns a callable that could transform the data line
+     *
+     * @return callable
+     */
+    public function getLineFormatter();
 }

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -197,3 +197,7 @@ assetic:
 ## List of available column types
 
 - [Columns](https://github.com/stwe/DatatablesBundle/blob/master/Resources/doc/columns.md)
+
+## Used a line formatter
+
+- [Line formatter](./lineFormatter.md)

--- a/Resources/doc/lineFormatter.md
+++ b/Resources/doc/lineFormatter.md
@@ -1,0 +1,60 @@
+# Use LineFormatter
+
+Format line directly by passing a closure in the DatatableView class. The 
+transformer modificate data after that orders and filters are apply. Use
+in thinking that to alter data couldn't change originals orders or filters.
+
+This function permit to centralize datatables operations and to securize 
+request by removing id and transform it in a slug.
+
+## Exemple
+
+```php
+<?php
+
+namespace Sg\BlogBundle\Datatables;
+
+use Sg\DatatablesBundle\Datatable\View\AbstractDatatableView;
+use Sg\DatatablesBundle\Column\ActionColumn;
+
+/**
+ * Class UserDatatable
+ *
+ * @package Sg\BlogBundle\Datatables
+ */
+class UserDatatable extends AbstractDatatableView
+{
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getLineFormatter()
+    {
+        $formatter = function($line){
+            $line['lastName'] = $line['lastName'] . ", " . $line['firstName'];
+            return $line;
+        };
+
+        return $formatter
+    }
+    
+
+    /**
+     * {@inheritdoc}
+     */
+    public function buildDatatableView()
+    {
+        $this->getFeatures()->setServerSide(false);
+
+        //...
+
+        $this
+            ->add("firstName", "column", array("visible"=>false))
+            ->add("lastName", "column")
+            //....
+        ;
+        // ...
+    }
+
+}
+```


### PR DESCRIPTION
Documentation : [see](https://github.com/nicodmf/DatatablesBundle/blob/2ea2f9e1c69bd9278ffbd87912a297848a20a3e0/Resources/doc/lineFormatter.md)
- change "transformer" to "formatter" in all method, function and parameters to have an uniform naming convention.
- change the callable to be compatible with old php version.
