### PR TITLE
Fixed turbolinks compatibility

### DIFF
--- a/Resources/views/Datatable/datatable.html.twig
+++ b/Resources/views/Datatable/datatable.html.twig
@@ -5,6 +5,12 @@
         {% include "SgDatatablesBundle:Datatable:datatable_html.html.twig" %}
 
     {% endblock %}
+    
+    {% block sg_datatable_render_functions %}
+
+        {% include "SgDatatablesBundle:Datatable:render_functions.html.twig" %}
+
+    {% endblock %}
 
     {% block sg_datatable_js %}
 
@@ -122,12 +128,6 @@
             });
 
         </script>
-
-    {% endblock %}
-
-    {% block sg_datatable_render_functions %}
-
-        {% include "SgDatatablesBundle:Datatable:render_functions.html.twig" %}
 
     {% endblock %}
 


### PR DESCRIPTION
Hi,

I'm using this bundle in project with turbolinks and I was getting javascript error `Uncaught ReferenceError: render_datetime is not defined`, when I visit page with datatable by clicking on link via turbolinks (standard browser refresh works normally).

I've fixed it by moving block `sg_datatable_render_functions` block on top of datatable initialization. I'm not sure if this change of order does not affect other funcionality, but everything worked well so far.
