### PR TITLE
Fix: datetime property of entity is null

### DIFF
--- a/Resources/views/Datatable/render_functions.html.twig
+++ b/Resources/views/Datatable/render_functions.html.twig
@@ -17,7 +17,7 @@
     }
 
     function render_datetime(data, type, row, meta, localizedFormat) {
-        if (typeof data.timestamp != "undefined") {
+        if (data != null && typeof data.timestamp != "undefined") {
             moment.lang("{{ app.request.locale }}");
             return moment.unix(data.timestamp).format(localizedFormat);
         } else {
@@ -26,7 +26,7 @@
     }
 
     function render_timeago(data, type, row, meta) {
-        if (typeof data.timestamp != "undefined") {
+        if (data != null && typeof data.timestamp != "undefined") {
             moment.lang("{{ app.request.locale }}");
             return moment.unix(data.timestamp).fromNow();
         } else {


### PR DESCRIPTION
Fixes an error, when datetime property of entity is null, javascript throws `Uncaught TypeError: Cannot read property 'timestamp' of null`
