### PR TITLE
Update for PHP 5.3 compatibility

### DIFF
--- a/Datatable/View/AbstractDatatableView.php
+++ b/Datatable/View/AbstractDatatableView.php
@@ -238,11 +238,6 @@ abstract class AbstractDatatableView implements DatatableViewInterface
     /**
      * {@inheritdoc}
      */
-    abstract public function buildDatatableView();
-
-    /**
-     * {@inheritdoc}
-     */
     public function renderDatatableView()
     {
         $options = array();
@@ -273,11 +268,6 @@ abstract class AbstractDatatableView implements DatatableViewInterface
     /**
      * {@inheritdoc}
      */
-    abstract public function getEntity();
-
-    /**
-     * {@inheritdoc}
-     */
     public function setAjax($ajax)
     {
         $this->ajax = $ajax;
@@ -292,11 +282,6 @@ abstract class AbstractDatatableView implements DatatableViewInterface
     {
         return $this->ajax;
     }
-
-    /**
-     * {@inheritdoc}
-     */
-    abstract public function getName();
 
 
     //-------------------------------------------------


### PR DESCRIPTION
Is there a reason to "implement" interface methods as abstract on this class?  Doing so just prevents PHP 5.3 users from being able to take advantage of this bundle.
