### PR TITLE
Add raw filter to DOM rendering

### DIFF
--- a/Resources/views/Datatable/options.html.twig
+++ b/Resources/views/Datatable/options.html.twig
@@ -1,7 +1,7 @@
 "displayStart": {{ view_options.displayStart }},
 
 {% if false == view_use_integration_options %}
-    "dom": "{{ view_options.dom }}",
+    "dom": "{{ view_options.dom|raw }}",
 {% endif %}
 
 "lengthMenu": {{ view_options.lengthMenu|length_join|raw }},


### PR DESCRIPTION
datatables accepts a dom string that uses "<" and ">" to create custom divs while rendering the various bits of the view. For example <'row'<'col-md-6'l><'col-md-6'f>r>t<'row'<'col-md-6'i><'col-md-6'p>> renders everything in bootstrap grid style rows and columns.

The option setDom gets rendered without the |raw twig filter - so this gets escaped as & l t ;'row' & l t;... etc. and so doesn't work as expected.

This PR just adds the |raw filter.

Also - this is the first PR I've done on any github project - apologies if I'm not following convention/protocol :)
