### PR TITLE
Automatically call buildDatatableView when rendering DataTable

### DIFF
--- a/Resources/doc/example.md
+++ b/Resources/doc/example.md
@@ -214,7 +214,6 @@ services:
 public function indexAction()
 {
     $postDatatable = $this->get("sg_datatables.post");
-    $postDatatable->buildDatatableView();
 
     return array(
         "datatable" => $postDatatable,
@@ -372,7 +371,6 @@ public function indexAction()
     $serializer = new Serializer($normalizers, $encoders);
 
     $postDatatable = $this->get('sg_datatables.post');
-    $postDatatable->buildDatatableView();
     $postDatatable->setData($serializer->serialize($results, 'json'));
 
     return array(

--- a/Twig/DatatableTwigExtension.php
+++ b/Twig/DatatableTwigExtension.php
@@ -122,6 +122,8 @@ class DatatableTwigExtension extends Twig_Extension
      */
     public function datatableRender(AbstractDatatableView $datatable)
     {
+        $datatable->buildDatatableView();
+
         return $datatable->renderDatatableView();
     }
 }


### PR DESCRIPTION
Since the `buildDatatableView()` always needs to be called, I think it is should automatically be done in the twig function, then it is not necessary to call it each time in the controller