### PR TITLE
Added column option to define custom order sequencing on clicks

### DIFF
--- a/Datatable/Column/AbstractColumn.php
+++ b/Datatable/Column/AbstractColumn.php
@@ -68,6 +68,13 @@ abstract class AbstractColumn implements ColumnInterface
     protected $orderable;
 
     /**
+     * Custom order sequencing for this column
+     *
+     * @var array
+     */
+    private $order_sequence;
+
+    /**
      * Render (process) the data for use in the table.
      *
      * @var null|string
@@ -267,6 +274,30 @@ abstract class AbstractColumn implements ColumnInterface
     public function getOrderable()
     {
         return $this->orderable;
+    }
+
+    /**
+     * Set order_sequence.
+     *
+     * @param array $order_sequence
+     *
+     * @return $this
+     */
+    public function setOrderSequence($order_sequence)
+    {
+        $this->order_sequence = $order_sequence;
+
+        return $this;
+    }
+
+    /**
+     * Get order_sequence.
+     *
+     * @return array
+     */
+    public function getOrderSequence()
+    {
+        return $this->order_sequence;
     }
 
     /**

--- a/Datatable/Column/Column.php
+++ b/Datatable/Column/Column.php
@@ -70,6 +70,7 @@ class Column extends AbstractColumn
         $this->setDefaultContent("");
         $this->setName("");
         $this->setOrderable(true);
+        $this->setOrderSequence(null);
         $this->setRender(null);
         $this->setSearchable(true);
         $this->setTitle("");
@@ -97,6 +98,9 @@ class Column extends AbstractColumn
         }
         if (array_key_exists("orderable", $options)) {
             $this->setOrderable($options["orderable"]);
+        }
+        if (array_key_exists("order_sequence", $options)) {
+            $this->setOrderSequence($options["order_sequence"]);
         }
         if (array_key_exists("render", $options)) {
             $this->setRender($options["render"]);

--- a/Resources/views/Column/column.html.twig
+++ b/Resources/views/Column/column.html.twig
@@ -13,6 +13,9 @@
         "name": "{{ column.name }}",
         {% if column.orderable %}
             "orderable": true,
+            {% if column.orderSequence is not empty %}
+                "orderSequence": {{ column.orderSequence|json_encode|raw }},
+            {% endif %}
         {% else %}
             "orderable": false,
         {% endif %}


### PR DESCRIPTION
Example usage:

$this->getColumnBuilder()->add('outreach', 'column', array('order_sequence' => array('desc', 'asc'));

Will sort the column desc on the first click, then asc on the second.