### PR TITLE
add possibility to set only one option

### DIFF
--- a/Datatable/View/AbstractDatatableView.php
+++ b/Datatable/View/AbstractDatatableView.php
@@ -179,6 +179,8 @@ abstract class AbstractDatatableView implements DatatableViewInterface
         $this->templates = $defaultLayoutOptions['templates'];
 
         $this->qb = null;
+
+        $this->buildDatatableView();
     }
 
     //-------------------------------------------------
@@ -190,8 +192,6 @@ abstract class AbstractDatatableView implements DatatableViewInterface
      */
     public function render($type = "all")
     {
-        $this->buildDatatableView();
-
         $options = array();
 
         if (true === $this->features->getServerSide()) {

--- a/Datatable/View/Options.php
+++ b/Datatable/View/Options.php
@@ -196,6 +196,8 @@ class Options
     /**
      * Set options.
      *
+     * All options not specified will be set to default.
+     *
      * @param array $options
      *
      * @return $this
@@ -204,6 +206,23 @@ class Options
     {
         $this->options = $this->resolver->resolve($options);
         $this->callingSettersWithOptions($this->options);
+
+        return $this;
+    }
+
+    /**
+     * Set one option.
+     *
+     * All the other parameters will not be altered.
+     *
+     * @param string $optionKey
+     * @param mixed  $optionValue
+     *
+     * @return $this
+     */
+    public function setOption($optionKey, $optionValue)
+    {
+        $this->callingSettersWithOptions(array($optionKey => $optionValue));
 
         return $this;
     }

--- a/Resources/views/Datatable/datatable_html.html.twig
+++ b/Resources/views/Datatable/datatable_html.html.twig
@@ -1,7 +1,7 @@
 <table cellpadding="0" cellspacing="0" class="{{ view_options.class }}" border="0" id="{{ view_table_id }}" width="100%">
     <thead>
     </thead>
-    {% if view_options.individualFiltering || view_multiselect %}
+    {% if view_options.individualFiltering or view_multiselect %}
         <tfoot>
             <tr>
                 {% for column in view_columns %}

--- a/Resources/views/Datatable/datatable_html.html.twig
+++ b/Resources/views/Datatable/datatable_html.html.twig
@@ -3,6 +3,7 @@
     </thead>
     {% if view_options.individualFiltering or view_multiselect %}
         <tfoot>
+            {% if view_options.individualFiltering %}
             <tr>
                 {% for column in view_columns %}
                     <td>
@@ -12,6 +13,7 @@
                     </td>
                 {% endfor %}
             </tr>
+            {% endif %}
         </tfoot>
     {% endif %}
     <tbody>

--- a/Resources/views/Datatable/datatable_html.html.twig
+++ b/Resources/views/Datatable/datatable_html.html.twig
@@ -1,7 +1,7 @@
 <table cellpadding="0" cellspacing="0" class="{{ view_options.class }}" border="0" id="{{ view_table_id }}" width="100%">
     <thead>
     </thead>
-    {% if view_options.individualFiltering %}
+    {% if view_options.individualFiltering || view_multiselect %}
         <tfoot>
             <tr>
                 {% for column in view_columns %}


### PR DESCRIPTION
Hello,

Migrating from 0.6.1 to 0.7, I found that setOptions is overriding possible previous calls of setOptions. It may be interesting to add a function setOption in order to have the same behaviour as "setParameters" and "setParameter" in Doctrine.

It is useful if you use a "BaseDatatable" which sets the default options using setOptions. Then you can extend BaseDatatable for your datatables and set the specific options one by one.

