### PR TITLE
Fix show multiselect actions even when individual filtering is disabled

### DIFF
--- a/Resources/views/Datatable/datatable_html.html.twig
+++ b/Resources/views/Datatable/datatable_html.html.twig
@@ -1,8 +1,9 @@
 <table cellpadding="0" cellspacing="0" class="{{ view_options.class }}" border="0" id="{{ view_table_id }}" width="100%">
     <thead>
     </thead>
-    {% if view_options.individualFiltering %}
+    {% if view_options.individualFiltering or view_multiselect %}
         <tfoot>
+            {% if view_options.individualFiltering %}
             <tr>
                 {% for column in view_columns %}
                     <td>
@@ -12,6 +13,7 @@
                     </td>
                 {% endfor %}
             </tr>
+            {% endif %}
         </tfoot>
     {% endif %}
     <tbody>


### PR DESCRIPTION
The javascript relies on a tfoot in the html. The tfoot was only displayed if individual filtering was disabled. With this fix it's not the case anymore.