### PR TITLE
Add possibility to set only one option

### DIFF
--- a/Datatable/View/Options.php
+++ b/Datatable/View/Options.php
@@ -196,6 +196,8 @@ class Options
     /**
      * Set options.
      *
+     * All options not specified will be set to default.
+     *
      * @param array $options
      *
      * @return $this
@@ -204,6 +206,23 @@ class Options
     {
         $this->options = $this->resolver->resolve($options);
         $this->callingSettersWithOptions($this->options);
+
+        return $this;
+    }
+
+    /**
+     * Set one option.
+     *
+     * All the other parameters will not be altered.
+     *
+     * @param string $optionKey
+     * @param mixed  $optionValue
+     *
+     * @return $this
+     */
+    public function setOption($optionKey, $optionValue)
+    {
+        $this->callingSettersWithOptions(array($optionKey => $optionValue));
 
         return $this;
     }


### PR DESCRIPTION
Hello,

Migrating from 0.6.1 to 0.7, I found that setOptions is overriding possible previous calls of setOptions. It may be interesting to add a function setOption in order to have the same behaviour as "setParameters" and "setParameter" in Doctrine.

It is useful if you use a "BaseDatatable" which sets the default options using setOptions. Then you can extend BaseDatatable for your datatables and set the specific options one by one.
