### PR TITLE
#157 fixed filter appearing twice on clientside mode

### DIFF
--- a/Resources/views/Datatable/datatable_js.html.twig
+++ b/Resources/views/Datatable/datatable_js.html.twig
@@ -46,11 +46,11 @@
             {% if view_options.individualFiltering %}
 
                 {% if "head" == view_options.individualFilteringPosition %}
-                    $(selector + '_wrapper tfoot tr').insertAfter($(selector + '_wrapper thead tr'));
+                    $(selector + '_wrapper tfoot tr').insertAfter($(selector + '_wrapper thead tr').last());
                 {% endif %}
 
                 {% if "both" == view_options.individualFilteringPosition %}
-                    $(selector + '_wrapper tfoot tr').clone().insertAfter($(selector + '_wrapper thead tr'));
+                    $(selector + '_wrapper tfoot tr').clone().insertAfter($(selector + '_wrapper thead tr').last());
                 {% endif %}
 
                 var daterange = $('input[name="daterange"]');


### PR DESCRIPTION
This problem occurs because the selector $(selector + '_wrapper thead tr') returns two rows (expected one): one is the table names, another is hidden (with zero height). 

The simple solution might be to insert the filters row after the last row in header, like this:
$(selector + '_wrapper tfoot tr').clone().insertAfter($(selector + '_wrapper thead tr').last());