### PR TITLE
Prevent reload on arrow and modifier keys

### DIFF
--- a/Resources/views/Datatable/datatable_js.html.twig
+++ b/Resources/views/Datatable/datatable_js.html.twig
@@ -68,6 +68,21 @@
                 {# "foot" position -> datatable_html.html.twig #}
 
                 $(selector + "_wrapper").find("tr input.individual_filtering").on("keyup change", function() {
+                    
+                    if ( event.type == "keyup" )
+                    {
+                        if (
+                                event.keyCode == 37 ||
+                                event.keyCode == 38 ||
+                                event.keyCode == 39 ||
+                                event.keyCode == 40 ||
+                                event.keyCode == 16 ||
+                                event.keyCode == 17 ||
+                                event.keyCode == 18
+                        )
+                        return;
+                    }
+                    
                     oTable
                         .column( $(this).parent().index()+':visible' )
                         .search( this.value )


### PR DESCRIPTION
Prevent datatable from doing a search if an arrow key or a modifier key (alt, ctrl, shift) is pressed on an individual filter input