### PR TITLE
Fixes JSON output in case the title field has embedded html.

### DIFF
--- a/Datatable/View/Ajax.php
+++ b/Datatable/View/Ajax.php
@@ -50,6 +50,13 @@ class Ajax
      */
     protected $type;
 
+    /**
+     * Send extra data in the request.
+     *
+     * @var string
+     */
+    protected $data;
+
     //-------------------------------------------------
     // Ctor.
     //-------------------------------------------------
@@ -95,11 +102,13 @@ class Ajax
     {
         $resolver->setDefaults(array(
             'url' => '',
-            'type' => 'GET'
+            'type' => 'GET',
+            'data' => '',
         ));
 
         $resolver->setAllowedTypes('url', 'string');
         $resolver->setAllowedTypes('type', 'string');
+        $resolver->setAllowedTypes('data', 'string');
 
         $resolver->setAllowedValues('type', array('GET', 'POST', 'get', 'post'));
 
@@ -182,4 +191,21 @@ class Ajax
     {
         return $this->type;
     }
+
+    /**
+     * @return mixed
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * @param mixed $data
+     */
+    public function setData($data)
+    {
+        $this->data = $data;
+    }
+
 }

--- a/Resources/views/Column/column.html.twig
+++ b/Resources/views/Column/column.html.twig
@@ -21,7 +21,7 @@
         {% else %}
             "searchable": false,
         {% endif %}
-        "title": "{{ column.title|raw }}",
+        "title": "{{ column.title|raw|e('js') }}",
         {% if column.type %}
             "type": "{{ column.type }}",
         {% endif %}

--- a/Resources/views/Datatable/ajax.html.twig
+++ b/Resources/views/Datatable/ajax.html.twig
@@ -3,6 +3,10 @@
     "ajax": {
         "url": "{{ view_ajax.url }}",
         "type": "{{ view_ajax.type }}"
+
+        {% if view_ajax.data %}
+        ,"data": {{ view_ajax.data|raw }}
+        {% endif %}
     },
 {% else %}
     "serverSide": false,


### PR DESCRIPTION
Hi!

I made this fix because I wasn't able to embed HTML in a column's title. The generated JSON output was invalid because the quote character was not being properly escaped.