### PR TITLE
Reverted from short array syntax to traditional

### DIFF
--- a/Datatable/Column/BooleanColumn.php
+++ b/Datatable/Column/BooleanColumn.php
@@ -105,7 +105,7 @@ class BooleanColumn extends AbstractColumn
             'width' => '',
             'search_type' => 'like',
             'filter_type' => 'select',
-            'filter_options' => ['' => 'Any', '1' => 'Yes', '0' => 'No'],
+            'filter_options' => array('' => 'Any', '1' => 'Yes', '0' => 'No'),
             'filter_property' => '',
             'filter_search_column' => '',
             'true_icon' => '',

--- a/Datatable/Column/Column.php
+++ b/Datatable/Column/Column.php
@@ -84,7 +84,7 @@ class Column extends AbstractColumn
             'width' => '',
             'search_type' => 'like',
             'filter_type' => 'text',
-            'filter_options' => [],
+            'filter_options' => array(),
             'filter_property' => '',
             'filter_search_column' => '',
             'default' => ''

--- a/Datatable/Column/TimeagoColumn.php
+++ b/Datatable/Column/TimeagoColumn.php
@@ -77,7 +77,7 @@ class TimeagoColumn extends AbstractColumn
             'width' => '',
             'search_type' => 'like',
             'filter_type' => 'text',
-            'filter_options' => [],
+            'filter_options' => array(),
             'filter_property' => '',
             'filter_search_column' => ''
         ));

--- a/Datatable/View/AbstractDatatableView.php
+++ b/Datatable/View/AbstractDatatableView.php
@@ -404,7 +404,7 @@ abstract class AbstractDatatableView implements DatatableViewInterface
      */
     public function getCollectionAsOptionsArray($entitiesCollection, $keyPropertyName = 'id', $valuePropertyName = 'name')
     {
-        $options = [];
+        $options = array();
 
         foreach ($entitiesCollection as $entity) {
             $keyPropertyName = Container::camelize($keyPropertyName);

--- a/Datatable/View/Options.php
+++ b/Datatable/View/Options.php
@@ -242,7 +242,7 @@ class Options
             'dom' => 'lfrtip',
             'length_menu' => array(10, 25, 50, 100),
             'order_classes' => true,
-            'order' => [[0, 'asc']],
+            'order' => array(array(0, 'asc')),
             'order_multi' => true,
             'page_length' => 10,
             'paging_type' => Style::FULL_NUMBERS_PAGINATION,
@@ -447,7 +447,7 @@ class Options
                 !array_key_exists(0, $o) ||
                 !is_numeric($o[0]) ||
                 !array_key_exists(1, $o) ||
-                !in_array($o[1], ['desc', 'asc'])){
+                !in_array($o[1], array('desc', 'asc'))){
                 throw new \Exception('setOrder(): Invalid array format.');
             }
         }

--- a/Resources/doc/example.md
+++ b/Resources/doc/example.md
@@ -98,7 +98,7 @@ class PostDatatable extends AbstractDatatableView
             'dom' => 'lfrtip', // default, but not used because 'use_integration_options' = true
             'length_menu' => array(10, 25, 50, 100),
             'order_classes' => true,
-            'order' => [[0, 'asc']],
+            'order' => array(array(0, 'asc')),
             'order_multi' => true,
             'page_length' => 10,
             'paging_type' => Style::FULL_NUMBERS_PAGINATION,

--- a/Resources/views/Skeleton/class.php.twig
+++ b/Resources/views/Skeleton/class.php.twig
@@ -52,7 +52,7 @@ class {{ datatable_class }} extends AbstractDatatableView
             'dom' => 'lfrtip',
             'length_menu' => array(10, 25, 50, 100),
             'order_classes' => true,
-            'order' => [[0, 'asc']],
+            'order' => array(array(0, 'asc')),
             'order_multi' => true,
             'page_length' => 10,
             'paging_type' => Style::FULL_NUMBERS_PAGINATION,

--- a/Twig/DatatableTwigExtension.php
+++ b/Twig/DatatableTwigExtension.php
@@ -166,7 +166,7 @@ class DatatableTwigExtension extends Twig_Extension
             $filterColumnId = $loopIndex;
         }
 
-        return $twig->render('SgDatatablesBundle:Filters:filter_' . $filterType . '.html.twig', ['column' => $column, 'filterColumnId' => $filterColumnId]);
+        return $twig->render('SgDatatablesBundle:Filters:filter_' . $filterType . '.html.twig', array('column' => $column, 'filterColumnId' => $filterColumnId));
     }
 
     /**


### PR DESCRIPTION
Changed every short array syntax to traditional array syntax to avoid
problems with projects using PHP 5.3


I used PHPStorm, changed PHP inspections to 5.3, run inspection 'short array syntax is only allowed in PHP 5.4 or above' and now it doesn't find any problem with short arrays so it should certainly be fixed.