### PR TITLE
Update DatatableQuery.php

### DIFF
--- a/Datatable/Data/DatatableQuery.php
+++ b/Datatable/Data/DatatableQuery.php
@@ -152,7 +152,15 @@ class DatatableQuery
         $this->entity = $this->datatableView->getEntity();
         $this->em = $this->datatableView->getEntityManager();
         $this->metadata = $this->getMetadata($this->entity);
-        $this->tableName = $this->getTableName($this->metadata);
+        
+        $keyName=$this->getTableName($metadata);
+        if(strpos($keyName, ".")){
+            $tableName = substr($keyName, strpos($keyName, ".") + 1);
+            $this->tableName = $tableName;
+        }else{
+            $this->tableName =$keyName;ge
+        }
+        
         $this->rootEntityIdentifier = $this->getIdentifier($this->metadata);
         $this->qb = $this->em->createQueryBuilder();
 
@@ -382,7 +390,13 @@ class DatatableQuery
     private function setSelectFrom()
     {
         foreach ($this->selectColumns as $key => $value) {
-            $this->qb->addSelect('partial ' . $key . '.{' . implode(',', $this->selectColumns[$key]) . '}');
+            if(strpos($key, ".")){
+                $tableName = substr($key, strpos($key, ".") + 1);
+            }else{
+                $tableName=$key;
+            }
+            
+            $this->qb->addSelect('partial ' . $tableName . '.{' . implode(',', $this->selectColumns[$key]) . '}');
         }
 
         $this->qb->from($this->entity, $this->tableName);


### PR DESCRIPTION
Using PostgreSQL, if I need to access one table in a secondary schema through the entity annotation:

/**
 * catpersonal
 * @ORM\Table(name="secondschema.catpersonal")
 * @ORM\Entity()
 */
class catpersonal


I got the error:
      Syntax Error] line 0, col 31: Error: Expected Doctrine\ORM\Query\Lexer::T_OPEN_CURLY_BRACE, got 'catpersonal'


and the query was made like this:
      SELECT partial secondschema.catpersonal.{id,cacpeNombre} FROM Catalogos\Bundle\GeneralesBundle\Entity\catpersonal secondschema.catpersonal

in this case the builder is setting the name of the schema and one dot, that was giving the error;
in this fix, If I set the name of the secondary schema in the name of the table is correctly removed (the name of the schema) to make the query, and it worked very well if I use schema or not.