### PR TITLE
fixed scrollY has wrong type in twig

### DIFF
--- a/Resources/views/Datatable/features.html.twig
+++ b/Resources/views/Datatable/features.html.twig
@@ -7,7 +7,7 @@
 "paging": {{ view_features.paging ? 'true' : 'false' }},
 "processing": {{ view_features.processing ? 'true' : 'false' }},
 "scrollX": {{ view_features.scrollX ? 'true' : 'false' }},
-"scrollY": {{ view_features.scrollY ? 'true' : 'false' }},
+"scrollY": "{{ view_features.scrollY }}",
 "searching": {{ view_features.searching ? 'true' : 'false' }},
 
 {# "serverSide" -> Ajax.html.twig #}


### PR DESCRIPTION
scrollY is a string instead of a boolean so the value should be inserted
https://datatables.net/reference/option/scrollY