### PR TITLE
Fix for Postgres compatibility, = added groupBy in count query

### DIFF
--- a/Datatable/Data/DatatableQuery.php
+++ b/Datatable/Data/DatatableQuery.php
@@ -622,6 +622,7 @@ class DatatableQuery
         $qb = $this->em->createQueryBuilder();
         $qb->select('count(distinct ' . $this->tableName . '.' . $rootEntityIdentifier . ')');
         $qb->from($this->entity, $this->tableName);
+        $qb->groupBy($this->tableName . '.' . $rootEntityIdentifier);
 
         $this->setLeftJoins($qb);
         $this->setWhereAllCallback($qb);
@@ -641,6 +642,7 @@ class DatatableQuery
         $qb = $this->em->createQueryBuilder();
         $qb->select('count(distinct ' . $this->tableName . '.' . $rootEntityIdentifier . ')');
         $qb->from($this->entity, $this->tableName);
+        $qb->groupBy($this->tableName . '.' . $rootEntityIdentifier);
 
         $this->setLeftJoins($qb);
         $this->setWhere($qb);


### PR DESCRIPTION
Hi,

When i tried using this bundle in a project with Postgres i got the following error message:
SQLSTATE[42803]: Grouping error: 7 ERROR: column "x.id" must appear in the GROUP BY clause or be used in an aggregate function

The querybuilder used 2 tables, with a join. The datatable entity table (x) with primary key id (int, auto increment) and a many-to-one relation (y). The join column was y.id. 

Environment:
ubuntu 
psql 9.3.10
php 5.5.9
symfony 2.7.5
datatablesbundle 0.7.1
