### PR TITLE
fix isNotNull() in case 'isNotNull':

### DIFF
--- a/Datatable/Data/DatatableQuery.php
+++ b/Datatable/Data/DatatableQuery.php
@@ -582,7 +582,7 @@ class DatatableQuery
                 $andExpr->add($pivot->expr()->isNull($searchField));
                 break;
             case 'isNotNull':
-                $andExpr->add($pivot->expr()->isNull($searchField));
+                $andExpr->add($pivot->expr()->isNotNull($searchField));
                 break;
         }
 


### PR DESCRIPTION
I was trying this:

```
 ->add('my_field', 'boolean', array(
                'searchable' => true,
                'visible' => true,
                'search_type' => 'isNotNull',
            ))
````
and it wasn't working

so I gave a look at the source, and noticed that the condition should be

```
$andExpr->add($pivot->expr()->isNotNull($searchField));
```

I didn't look all the code, but this is working now