### PR TITLE
Support nested associations

### DIFF
--- a/Datatable/Data/DatatableQuery.php
+++ b/Datatable/Data/DatatableQuery.php
@@ -183,8 +183,15 @@ class DatatableQuery
 
                     while (count($array) > 2) {
                         // Add any missing relations
-                        $this->selectColumns[$array[1]][] = 'id';
-                        $this->joins[$array[0] . '.' . $array[1]] = $array[1];
+                        if (!isset($this->selectColumns[$array[1]]) || array_search('id', $this->selectColumns[$array[1]]) === false) {
+                            $this->selectColumns[$array[1]][] = 'id';
+                        }
+
+                        $joinKey = $array[0] . '.' . $array[1];
+                        if (!isset($this->joins[$joinKey])) {
+                            $this->joins[$joinKey] = $array[1];
+                        }
+
                         array_shift($array);
                     }
 

--- a/Datatable/Data/DatatableQuery.php
+++ b/Datatable/Data/DatatableQuery.php
@@ -179,26 +179,17 @@ class DatatableQuery
                     }
                 } else {
                     $array = explode('.', $data);
-                    $count = count($array);
+                    array_unshift($array, $this->tableName);
 
-                    if ($count > 2) {
-                        $replaced = str_replace('.', '_', $data);
-                        $parts = explode('_', $replaced);
-                        $last = array_pop($parts);
-                        $select = implode('_', $parts);
-                        $join = str_replace('_', '.', $select);
-                        $this->selectColumns[$select][] = $last;
-
-                        $this->selectColumns[$array[0]][] = 'id';
-                        $this->joins[$this->tableName . '.' . $array[0]] = $array[0];
-
-                        $this->joins[$join] = $select;
-                        $this->addSearchOrderColumn($key, $select, $last);
-                    } else {
-                        $this->selectColumns[$array[0]][] = $array[1];
-                        $this->joins[$this->tableName . '.' . $array[0]] = $array[0];
-                        $this->addSearchOrderColumn($key, $array[0], $array[1]);
+                    while (count($array) > 2) {
+                        // Add any missing relations
+                        $this->selectColumns[$array[1]][] = 'id';
+                        $this->joins[$array[0] . '.' . $array[1]] = $array[1];
+                        array_shift($array);
                     }
+
+                    $this->selectColumns[$array[0]][] = $array[1];
+                    $this->addSearchOrderColumn($key, $array[0], $array[1]);
                 }
             } else {
                 $this->orderColumns[] = null;


### PR DESCRIPTION
This fixes #182 "4th level associations not working".  I have successfully tested it with associations from 1 to 5 levels deep.

This PR is based off version 0.7.1, which is the version I'm using, so it unfortunately cannot be merged as-is.  Additional changes will be needed to make it work with the newer `setIdentifierFromAssociation()` method calls.  Nevertheless, I wanted to submit it anyway to help you kick-start resolution of this issue.