### PR TITLE
Add searchDelay to individual column filtering

### DIFF
--- a/Resources/views/Datatable/datatable_js.html.twig
+++ b/Resources/views/Datatable/datatable_js.html.twig
@@ -107,26 +107,31 @@
 
                 {# "foot" position -> datatable_html.html.twig #}
 
-                $(selector + "_wrapper").find("tr input.individual_filtering").on("keyup change", function(event) {
-                    if ( event.type == "keyup" ) {
-                        console.log('return: ' + event.keyCode);
-                        if (
-                                event.keyCode == 37 ||
-                                event.keyCode == 38 ||
-                                event.keyCode == 39 ||
-                                event.keyCode == 40 ||
-                                event.keyCode == 16 ||
-                                event.keyCode == 17 ||
-                                event.keyCode == 18
-                           )
-                        return;
-                    }
+                var throttledSearch = $.fn.dataTable.util.throttle(
+			        function (event) {
+			            if ( event.type == "keyup" ) {
+	                        console.log('return: ' + event.keyCode);
+	                        if (
+	                                event.keyCode == 37 ||
+	                                event.keyCode == 38 ||
+	                                event.keyCode == 39 ||
+	                                event.keyCode == 40 ||
+	                                event.keyCode == 16 ||
+	                                event.keyCode == 17 ||
+	                                event.keyCode == 18
+	                           )
+	                        return;
+	                    }
 
-                    oTable
-                        .column( $(this).parent().index()+':visible' )
-                        .search( this.value )
-                        .draw();
-                });
+	                    oTable
+	                        .column( $(this).parent().index()+':visible' )
+	                        .search( this.value )
+	                        .draw();
+			        },
+			        options.searchDelay
+			    );
+                
+                $(selector + "_wrapper").find("tr input.individual_filtering").on("keyup change", throttledSearch);
 
                 $(selector + "_wrapper" + " select.individual_filtering").on("keyup change", function(event) {
                     var searchFieldId = $(event.currentTarget).data('filter-property-id');


### PR DESCRIPTION
Add searchDelay option to individual column filtering with the "throttle" util from Datatable API.