### PR TITLE
implements helper templates

### DIFF
--- a/Datatable/Column/AbstractColumn.php
+++ b/Datatable/Column/AbstractColumn.php
@@ -664,4 +664,14 @@ abstract class AbstractColumn implements ColumnInterface, OptionsInterface
     {
         return $this->tableName;
     }
+
+    /**
+     * Get helper template.
+     *
+     * @return string
+     */
+    public function getHelperTemplate()
+    {
+        return null;
+    }
 }

--- a/Datatable/Column/ColumnInterface.php
+++ b/Datatable/Column/ColumnInterface.php
@@ -51,6 +51,13 @@ interface ColumnInterface
     public function getTemplate();
 
     /**
+     * Get helper template.
+     *
+     * @return string
+     */
+    public function getHelperTemplate();
+
+    /**
      * Get alias.
      *
      * @return string

--- a/Datatable/Data/DatatableQuery.php
+++ b/Datatable/Data/DatatableQuery.php
@@ -11,12 +11,14 @@
 
 namespace Sg\DatatablesBundle\Datatable\Data;
 
+use Sg\DatatablesBundle\Datatable\Column\Column;
 use Sg\DatatablesBundle\Datatable\View\DatatableViewInterface;
 use Sg\DatatablesBundle\Datatable\Column\AbstractColumn;
 use Sg\DatatablesBundle\Datatable\Column\ImageColumn;
 use Sg\DatatablesBundle\Datatable\Column\GalleryColumn;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\PropertyAccess\Exception\InvalidArgumentException;
 use Doctrine\ORM\Mapping\ClassMetadata;
@@ -730,7 +732,7 @@ class DatatableQuery
                 $item = call_user_func($callable, $item);
             }
 
-            // Images
+            // Handle custom / helper templates
             foreach ($this->columns as $column) {
                 $data = $column->getDql();
 
@@ -769,6 +771,19 @@ class DatatableQuery
                     } else {
                         throw new InvalidArgumentException('getResponse(): Bundle "LiipImagineBundle" does not exist or it is not enabled.');
                     }
+                }
+
+                /** @var Column $column */
+                if (null !== $column->getHelperTemplate()) {
+                    $_data = $item;
+                    foreach($columnNames = explode('.', $data) as $part) {
+                        $_data = $_data[$part];
+                    }
+
+                    $item[implode('_', $columnNames)] = $this->twig->render($column->getHelperTemplate(), [
+                        'data' => $_data,
+                        'column' => $column
+                    ]);
                 }
             }
 

--- a/Resources/doc/columns.md
+++ b/Resources/doc/columns.md
@@ -11,6 +11,7 @@
 9. [Image Column](#9-image-column)
 10. [Gallery Column](#10-gallery-column)
 11. [ProgressBar Column](#11-progress-bar-column)
+12. [Make your own](#11-make-your-own-column)
 
 ## 1. Column
 
@@ -708,3 +709,47 @@ $this->columnBuilder
     ))
 ;
 ```
+
+
+## 12. Make your own
+
+In some case, you'll need to create new Column to fit your custom needs.
+To do so, you'll simply have to create a class extending the `Sg\DatatablesBundle\Datatable\Column\AbstractColumn` and
+use it in the Datatable class:
+
+```php
+    ...
+    $this->columnBuilder
+        ->add('title', new MyOwnColumn(), [...])
+        ->add('client.name', new MyOtherOwnColumn(), [...])
+    ...
+```
+.
+
+- Define `getTemplate` to talk to datatables api : (ex. `SgDatatablesBundle:Column:column.html.twig`)
+- Define `getHelperTemplate` to define complexe and custom template : (ex. `SgDatatablesBundle:Helper:your_helper_template.html.twig`)
+
+The entry point is in `DatatableQuery`::`getResponse()` method:
+
+```php
+...
+    /** @var Column $column */
+    if (null !== $column->getHelperTemplate()) {
+        $_data = $item;
+        foreach($columnNames = explode('.', $data) as $part) {
+            $_data = $_data[$part];
+        }
+
+        $item[implode('_', $columnNames)] = $this->twig->render($column->getHelperTemplate(), [
+            'data' => $_data,
+            'column' => $column
+        ]);
+    }
+...
+```
+
+You can notice we render the helper template with the `data` (ex. `name` or `client.name` in a ManyToOne case) and the
+whole `column` instance so you'll be able to access to them in the `helper template`.
+
+
+- Define `configureOptions` to be able to pass some options when using your column.


### PR DESCRIPTION
Hello,

I had to create a custom column to show some complex template (like you did for the `image` column and the `ii_render_image.html.twig` / `render_image.html.twig`).

I introduced a new `getHelperTemplate` method in the `AbstractColumn`. 
The entry point is in `DatatableQuery`::`getResponse()` method:

```php
...
    /** @var Column $column */
    if (null !== $column->getHelperTemplate()) {
        $_data = $item;
        foreach($columnNames = explode('.', $data) as $part) {
            $_data = $_data[$part];
        }

        $item[implode('_', $columnNames)] = $this->twig->render($column->getHelperTemplate(), [
            'data' => $_data,
            'column' => $column
        ]);
    }
...
```

You can notice we render the helper template with the `data value` (ex. `name` value or `client.name` value in a `ManyToOne` case) and the whole `column` instance so you'll be able to access to them in the `helper template`.