### PR TITLE
[#269] Fixed x-editable box problem (hidden by the table) when scroll-x=true.

### DIFF
--- a/Resources/views/Datatable/editable.html.twig
+++ b/Resources/views/Datatable/editable.html.twig
@@ -24,6 +24,7 @@
 
                     return params;
                 },
+                container: 'body',
                 {# many-to-one association needs a complete table redraw #}
                 {% if column.isAssociation %}
                 success: function(response, newValue) {


### PR DESCRIPTION
Fixed the x-editable problem (#269) specifying the container attribute as something outside of the table (e.g. body).