### PR TITLE
raw url twig output

### DIFF
--- a/Resources/views/Datatable/ajax.html.twig
+++ b/Resources/views/Datatable/ajax.html.twig
@@ -1,7 +1,7 @@
 {% if view_features.serverSide %}
     "serverSide": true,
     "ajax": {
-        "url": "{{ view_ajax.url }}",
+        "url": "{{ view_ajax.url|raw }}",
         "type": "{{ view_ajax.type }}"
     },
 {% else %}


### PR DESCRIPTION
raw url twig output to avoid htmlentities chars with GET params