### PR TITLE
remove asset function on elements that use imagine_filter

### DIFF
--- a/Resources/views/Helper/ii_render_image.html.twig
+++ b/Resources/views/Helper/ii_render_image.html.twig
@@ -11,7 +11,7 @@
     {% if image_name %}
         {% if enlarge %}
             <a href="javascript:void(0);" id="sg-enlarge_{{ image_id }}">
-                <img class="sg-thumbnail" src="{{ asset(path) | imagine_filter(filter) }}" />
+                <img class="sg-thumbnail" src="{{ path | imagine_filter(filter) }}" />
             </a>
 
             <div class="modal fade" id="sg-image-modal_{{ image_id }}">
@@ -39,7 +39,7 @@
                 });
             </script>
         {% else %}
-            <img class="sg-thumbnail" src="{{ asset(path) | imagine_filter(filter) }}" />
+            <img class="sg-thumbnail" src="{{ path | imagine_filter(filter) }}" />
         {% endif %}
     {% else %}
         {% if holder_url %}


### PR DESCRIPTION
Template **ii_render_image.html.twig** not work with **imagine_filter**. remove asset function to work fine with liipImagine bundle