### PR TITLE
Adds attribute data-filter-property-id for all filters

### DIFF
--- a/Resources/views/Filters/filter_daterange.html.twig
+++ b/Resources/views/Filters/filter_daterange.html.twig
@@ -11,6 +11,7 @@
            class="individual_filtering sg-daterange{% if column.filter.class %} {{ column.filter.class }}{% endif %}"
            style="{% if column.width %} width:{{ column.width }};{% endif %}"
            placeholder="{{ column.title|striptags|trim }}"
+           data-filter-property-id="{{ filterColumnId }}"
            {% if column.name %}name="{{ column.name }}"{% endif %} />
 {% endblock %}
 {% block javascript %}

--- a/Resources/views/Filters/filter_text.html.twig
+++ b/Resources/views/Filters/filter_text.html.twig
@@ -11,8 +11,8 @@
            class="individual_filtering{% if column.filter.class %} {{ column.filter.class }}{% endif %}"
            style="{% if column.width %} width:{{ column.width }};{% endif %}"
            placeholder="{{ column.title|striptags|trim }}"
+           data-filter-property-id="{{ filterColumnId }}"
            {% if column.name %}name="{{ column.name }}"{% endif %} />
 {% endblock %}
 {% block javascript %}
 {% endblock %}
-


### PR DESCRIPTION
Hello
I need restoring the filter values after page refresh. The Datatable successfully load the filter values from local storage and make server-side query. This working perfect. But inputs (input.individual_filtering and etc.) not restore own values. I don't find solution better than the state_load_param callback.

```

function (settings, data)
{
    try {
        if (data) {
            data.columns.forEach(function(column, i, columns) {
                var object = $("#{{view_table_id}} .individual_filtering[data-filter-property-id="+i+"]");
                if (!object) {
                    return;
                }

                if (object.is("select")) {
                    object.select2("val", column.search.search);
                } else if (object.is("input")) {
                    object.val(column.search.search);
                }
            });
        }
    } catch (e) {
        console.log(e);
    }
}
```
You can see what i use the data-filter-property-id attribute for mapping the columns array with individual filtering inputs. Unfortunately the data-filter-property-id defined only in the filter_select.html.twig