### PR TITLE
Adding 'data' for ajax setup

### DIFF
--- a/Datatable/Column/ColumnBuilder.php
+++ b/Datatable/Column/ColumnBuilder.php
@@ -182,4 +182,27 @@ class ColumnBuilder implements ColumnBuilderInterface
     {
         return (boolean) $this->multiselect;
     }
+
+    /**
+     * Set tableName
+     *
+     * @param string $tableName
+     * @return \Sg\DatatablesBundle\Datatable\Column\ColumnBuilder
+     */
+    public function setTableName($tableName)
+    {
+        $this->tableName = $tableName;
+
+        return $this;
+    }
+
+    /**
+     * Get tableName
+     *
+     * @return string
+     */
+    public function getTableName()
+    {
+        return $this->tableName;
+    }
 }

--- a/Datatable/View/Ajax.php
+++ b/Datatable/View/Ajax.php
@@ -45,11 +45,13 @@ class Ajax extends AbstractViewOptions
     {
         $resolver->setDefaults(array(
             'url' => '',
-            'type' => 'GET'
+            'type' => 'GET',
+            'data' => ''
         ));
 
         $resolver->setAllowedTypes('url', 'string');
         $resolver->setAllowedTypes('type', 'string');
+        $resolver->setAllowedTypes('data', 'string');
 
         $resolver->setAllowedValues('type', array('GET', 'POST', 'get', 'post'));
 
@@ -106,5 +108,30 @@ class Ajax extends AbstractViewOptions
     public function getType()
     {
         return $this->type;
+    }
+
+
+    /**
+     * Set Data.
+     *
+     * @param string $data
+     *
+     * @return $this
+     */
+    protected function setData($data)
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    /**
+     * Get Data.
+     *
+     * @return string
+     */
+    public function getData()
+    {
+        return $this->data;
     }
 }

--- a/Resources/doc/setup.md
+++ b/Resources/doc/setup.md
@@ -222,6 +222,7 @@ function order() {
 |------  |--------|---------|
 | url    | string | ''      |
 | type   | string | 'GET'   |
+| data   | string | ''      |
 
 ## 8. Name
 Since the datatable class should extend the ``AbstractDatatableView`` and this one implements ``DatatableViewInterface``, a ``getName`` method is required. The returned value **must only include letters, numbers, underscores or dashes** as it will be a seed for the id of the generated container of the datatable.

--- a/Resources/views/Column/column.html.twig
+++ b/Resources/views/Column/column.html.twig
@@ -57,4 +57,4 @@
             },
         {% endif %}
     {% endblock %}
-},
+}

--- a/Resources/views/Datatable/ajax.html.twig
+++ b/Resources/views/Datatable/ajax.html.twig
@@ -2,6 +2,7 @@
     "serverSide": true,
     "ajax": {
         "url": "{{ view_ajax.url }}",
+{% if view_ajax.data %}        "data": {{ view_ajax.data }},{% endif %}
         "type": "{{ view_ajax.type }}"
     },
 {% else %}

--- a/Resources/views/Datatable/columns.html.twig
+++ b/Resources/views/Datatable/columns.html.twig
@@ -1,5 +1,6 @@
 "columns": [
     {% for column in view_columns %}
+         {% if loop.index > 1 %},{% endif %}
         {% include column.getTemplate %}
     {% endfor %}
 ]


### PR DESCRIPTION
Sometimes we needs to add more data on Ajax request, Datatable allow that with "ajax.data".
These changes allow the use of that option