### PR TITLE
use parent service instead of tagging datatables view class

### DIFF
--- a/DependencyInjection/Compiler/DatatableViewPass.php
+++ b/DependencyInjection/Compiler/DatatableViewPass.php
@@ -32,6 +32,8 @@ class DatatableViewPass implements CompilerPassInterface
         $taggedServices = $container->findTaggedServiceIds('sg.datatable.view');
 
         foreach ($taggedServices as $id => $tags) {
+            @trigger_error("Tagging datatables view services is deprecated. Use 'sg_datatables.view.abstract' as parent service", E_USER_DEPRECATED);
+
             $def = $container->getDefinition($id);
             $def->addArgument(new Reference('security.authorization_checker'));
             $def->addArgument(new Reference('security.token_storage'));

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,18 +1,38 @@
 services:
     sg_datatables.serializer.method:
         class: Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer
+
     sg_datatables.serializer.encoder.json:
         class: Symfony\Component\Serializer\Encoder\JsonEncoder
+
     sg_datatables.serializer:
         class: Symfony\Component\Serializer\Serializer
         arguments:
             - ['@sg_datatables.serializer.method']
             - ['@sg_datatables.serializer.encoder.json']
+
     sg_datatables.twig.extension:
         class: Sg\DatatablesBundle\Twig\DatatableTwigExtension
         arguments: ['@translator']
         tags:
             - { name: twig.extension }
+
+    sg_datatables.view.abstract:
+        class: Sg\DatatablesBundle\Datatable\View\AbstractDatatableView
+        abstract: true
+        arguments:
+            - '@security.authorization_checker'
+            - '@security.token_storage'
+            - '@twig'
+            - '@translator.default'
+            - '@router'
+            - '@doctrine.orm.entity_manager'
+            - '%sg_datatables.datatable.templates%'
+
     sg_datatables.query:
         class: Sg\DatatablesBundle\Datatable\Data\DatatableDataManager
-        arguments: ['@request_stack', '@sg_datatables.serializer', %sg_datatables.datatable.query%, %kernel.bundles%]
+        arguments:
+            - '@request_stack'
+            - '@sg_datatables.serializer'
+            - '%sg_datatables.datatable.query%'
+            - '%kernel.bundles%'

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -94,8 +94,7 @@ $ php app/console sg:datatable:generate AppBundle:Post
 ```yaml
 app.datatable.post:
     class: AppBundle\Datatables\PostDatatable
-    tags:
-        - { name: sg.datatable.view }
+    parent: sg_datatables.view.abstract
 ```
 
 ### Step 6: Create your index.html.twig


### PR DESCRIPTION
Fixes #322 

I've added a user deprecation notice into the compiler pass to not break BC.
Should be removed in a future version