### PR TITLE
Use the quoted table name if necessary

### DIFF
--- a/Datatable/Data/DatatableQuery.php
+++ b/Datatable/Data/DatatableQuery.php
@@ -854,7 +854,7 @@ class DatatableQuery
      */
     private function getTableName(ClassMetadata $metadata)
     {
-        return strtolower($metadata->getTableName());
+        return strtolower($metadata->getQuotedTableName());
     }
 
     /**


### PR DESCRIPTION
Sometimes it is necessary to quote the table name and in this case the information is stored in the metadata. But getTableName() returns the raw table name (without any quote)

It may be necessary to do the same for the table fields but I don't have the time to dig into that.