### PR TITLE
Add type hinting for DatatableQuery callables

### DIFF
--- a/Datatable/Data/DatatableQuery.php
+++ b/Datatable/Data/DatatableQuery.php
@@ -399,7 +399,7 @@ class DatatableQuery
      *
      * @return $this
      */
-    public function addWhereResult($callback)
+    public function addWhereResult(callable $callback)
     {
         $this->callbacks['WhereResult'][] = $callback;
 
@@ -413,7 +413,7 @@ class DatatableQuery
      *
      * @return $this
      */
-    public function addWhereAll($callback)
+    public function addWhereAll(callable $callback)
     {
         $this->callbacks['WhereAll'][] = $callback;
 
@@ -475,7 +475,7 @@ class DatatableQuery
      *
      * @return $this
      */
-    public function addResponseCallback($callback)
+    public function addResponseCallback(callable $callback)
     {
         $this->callbacks['Response'][] = $callback;
 


### PR DESCRIPTION
Callback should be validated against callable either in setters or just before attempt to call callback.

For example
```
$query->addWhereAll(1);
```
will fail because integer given and callable expected there.

we can fix it for methods with callbacks like
```
    public function addWhereAll(callable $callback)
```

or as alternative check for callable before call like

```
is_callable($callback) && $callback($qb);
```

I'd prefer type hinting in method signatures