### PR TITLE
Prevented doctrine reserved keyword to be parsed

### DIFF
--- a/Datatable/Data/DatatableQuery.php
+++ b/Datatable/Data/DatatableQuery.php
@@ -656,7 +656,7 @@ class DatatableQuery
     private function getCountAllResults($rootEntityIdentifier)
     {
         $qb = $this->em->createQueryBuilder();
-        $qb->select('count(distinct ' . $this->tableName . '.' . $rootEntityIdentifier . ')');
+        $qb->select('count(\'distinct ' . $this->tableName . '.' . $rootEntityIdentifier . '\')');
         $qb->from($this->entity, $this->tableName);
 
         $this->setLeftJoins($qb);
@@ -677,7 +677,7 @@ class DatatableQuery
     {
         if (true === $buildQuery) {
             $qb = $this->em->createQueryBuilder();
-            $qb->select('count(distinct ' . $this->tableName . '.' . $rootEntityIdentifier . ')');
+            $qb->select('count(\'distinct ' . $this->tableName . '.' . $rootEntityIdentifier . '\')');
             $qb->from($this->entity, $this->tableName);
 
             $this->setLeftJoins($qb);


### PR DESCRIPTION
Without this fix, it is impossible to have a `Member` entity, for example.

![screenshot from 2016-05-07 17-20-23](https://cloud.githubusercontent.com/assets/668604/15092919/057eda3c-1478-11e6-85a9-4204b2784c4a.png)
