### PR TITLE
add imagineFilterEnlarged parameter

### DIFF
--- a/Datatable/Column/ImageColumn.php
+++ b/Datatable/Column/ImageColumn.php
@@ -25,13 +25,24 @@ use Twig_Environment;
 class ImageColumn extends AbstractColumn
 {
     /**
-     * The imagine filter.
+     * The imagine filter used to display image preview.
      *
      * @link https://github.com/liip/LiipImagineBundle#basic-usage
      *
      * @var string
      */
     protected $imagineFilter;
+
+    /**
+     * The imagine filter used to display the enlarged image's size;
+     * if not set or null, no filter will be applied;
+     * $enlarged need to be set to true.
+     *
+     * @link https://github.com/liip/LiipImagineBundle#basic-usage
+     *
+     * @var string
+     */
+    protected $imagineFilterEnlarged;
 
     /**
      * The relative path.
@@ -129,6 +140,7 @@ class ImageColumn extends AbstractColumn
                 'image_id' => 'sg_image_' . uniqid(rand(10000, 99999)),
                 'image_name' => $imageName,
                 'filter' => $this->getImagineFilter(),
+                'enlarged_filter' => $this->getImagineFilterEnlarged(),
                 'path' => $this->getRelativePath(),
                 'holder_url' => $this->getHolderUrl(),
                 'width' => $this->getHolderWidth(),
@@ -169,6 +181,7 @@ class ImageColumn extends AbstractColumn
             'width' => '',
             'filter' => array('text', array()),
             'imagine_filter' => '',
+            'imagine_filter_enlarged' => null,
             'holder_url' => '',
             'holder_width' => '50',
             'holder_height' => '50',
@@ -186,6 +199,7 @@ class ImageColumn extends AbstractColumn
         $resolver->setAllowedTypes('width', 'string');
         $resolver->setAllowedTypes('filter', 'array');
         $resolver->setAllowedTypes('imagine_filter', 'string');
+        $resolver->setAllowedTypes('imagine_filter_enlarged', 'string');
         $resolver->setAllowedTypes('relative_path', 'string');
         $resolver->setAllowedTypes('holder_url', 'string');
         $resolver->setAllowedTypes('holder_width', 'string');
@@ -221,6 +235,30 @@ class ImageColumn extends AbstractColumn
     public function getImagineFilter()
     {
         return $this->imagineFilter;
+    }
+
+    /**
+     * Set imagineFilterEnlarged.
+     *
+     * @param string $imagineFilterEnlarged
+     *
+     * @return $this
+     */
+    public function setImagineFilterEnlarged($imagineFilterEnlarged)
+    {
+        $this->imagineFilterEnlarged = $imagineFilterEnlarged;
+
+        return $this;
+    }
+
+    /**
+     * Get imagineFilterEnlarged.
+     *
+     * @return string
+     */
+    public function getImagineFilterEnlarged()
+    {
+        return $this->imagineFilterEnlarged;
     }
 
     /**

--- a/Resources/doc/columns.md
+++ b/Resources/doc/columns.md
@@ -559,24 +559,25 @@ SgDatatablesBundle:Column:image.html.twig
 
 ### Options
 
-| Option               | Type           | Default                |          |
-|----------------------|----------------|------------------------|----------|
-| class                | string         | ''                     |          |
-| padding              | string         | ''                     |          |
-| name                 | string         | ''                     |          |
-| orderable            | boolean        | false                  |          |
-| searchable           | boolean        | false                  |          |
-| title                | string         | ''                     |          |
-| type                 | string         | ''                     |          |
-| visible              | boolean        | true                   |          |
-| width                | string         | ''                     |          |
-| filter               | array          | array('text', array()) |          |
-| imagine_filter       | string         | ''                     |          |
-| relative_path        | string         |                        | required |
-| holder_url           | string         | ''                     |          |
-| holder_width         | string         | '50'                   |          |
-| holder_height        | string         | '50'                   |          |
-| enlarge              | boolean        | false                  |          |
+| Option                   | Type           | Default                |          |
+|--------------------------|----------------|------------------------|----------|
+| class                    | string         | ''                     |          |
+| padding                  | string         | ''                     |          |
+| name                     | string         | ''                     |          |
+| orderable                | boolean        | false                  |          |
+| searchable               | boolean        | false                  |          |
+| title                    | string         | ''                     |          |
+| type                     | string         | ''                     |          |
+| visible                  | boolean        | true                   |          |
+| width                    | string         | ''                     |          |
+| filter                   | array          | array('text', array()) |          |
+| imagine_filter           | string         | ''                     |          |
+| imagine_filter_enlarged  | string         | ''                     |          |
+| relative_path            | string         |                        | required |
+| holder_url               | string         | ''                     |          |
+| holder_width             | string         | '50'                   |          |
+| holder_height            | string         | '50'                   |          |
+| enlarge                  | boolean        | false                  |          |
 
 ### Example
 
@@ -586,6 +587,7 @@ $this->columnBuilder
         'title' => 'Bild',
         'relative_path' => 'images/posts',
         //'imagine_filter' => 'my_thumb_40x40',
+        //'imagine_filter_enlarged' => 'my_thumb_500x500',
         //'holder_url' => 'https://placehold.it',
         //'holder_width' => '65',
         //'holder_height' => '65',

--- a/Resources/views/Helper/ii_render_image.html.twig
+++ b/Resources/views/Helper/ii_render_image.html.twig
@@ -33,7 +33,10 @@
             <script type="text/javascript">
                 $(function() {
                     $("#sg-enlarge_{{ image_id }}").on("click", function() {
-                        $("#sg-imageview_{{ image_id }}").attr("src", "{{ asset(path) }}");
+                        {% if enlarged_filter %}
+                            {% set enlargedPath = asset(path)|imagine_filter(enlarged_filter) %}
+                        {% endif %}
+                        $("#sg-imageview_{{ image_id }}").attr("src", "{{ enlargedPath|default(asset(path)) }}");
                         $("#sg-image-modal_{{ image_id }}").modal("show");
                     });
                 });


### PR DESCRIPTION
in `Resources/views/Helper/ii_render_image.html.twig`, when the `enlarge` config is true, a modale opens and show the image without filter, the new `imagineFilterEnlarged` parameter allow us to set a filter for this picture which might be really big (true story) and kill some cats. 