### PR TITLE
Remove groupBy DQL part for datatable count methods

### DIFF
--- a/Datatable/Data/DatatableQuery.php
+++ b/Datatable/Data/DatatableQuery.php
@@ -656,6 +656,7 @@ class DatatableQuery
 
         $this->setLeftJoins($qb);
         $this->setWhereAllCallback($qb);
+        $qb->resetDQLPart('groupBy');
 
         return (int) $qb->getQuery()->getSingleScalarResult();
     }
@@ -678,6 +679,7 @@ class DatatableQuery
             $this->setLeftJoins($qb);
             $this->setWhere($qb);
             $this->setWhereAllCallback($qb);
+            $qb->resetDQLPart('groupBy');
 
             return (int) $qb->getQuery()->getSingleScalarResult();
         } else {
@@ -690,6 +692,7 @@ class DatatableQuery
                 $this->qb->groupBy($this->tableName . '.' . $rootEntityIdentifier);
                 return count($this->qb->getQuery()->getResult());
             } else {
+                $this->qb->resetDQLPart('groupBy');
                 return (int) $this->qb->getQuery()->getSingleScalarResult();
             }
         }


### PR DESCRIPTION
In case DQL got `groupBy` part somehow (callback, set query etc), `->getSingleScalarResult()` will fail with `The query returned multiple rows`.

Issue persists both on v.0.10 and on master.
This pull fix issue for master only.
