### PR TITLE
Two new functions for datetime column

### DIFF
--- a/Resources/views/Datatable/render_functions.js.twig
+++ b/Resources/views/Datatable/render_functions.js.twig
@@ -33,10 +33,28 @@ function render_datetime(data, type, row, meta, dateFormat) {
     }
 }
 
+function render_datetime_from_timestamp(data, type, row, meta, dateFormata) {
+    if (data != null && typeof data != "undefined") {
+        moment.locale("{{ app.request.locale }}");
+        return moment.unix(data).format(dateFormat);
+    } else {
+        return null;
+    }
+}
+
 function render_timeago(data, type, row, meta) {
     if (data != null && typeof data.timestamp != "undefined") {
         moment.locale("{{ app.request.locale }}");
         return moment.unix(data.timestamp).fromNow();
+    } else {
+        return null;
+    }
+}
+
+function render_timeago_from_timestamp(data, type, row, meta) {
+    if (data != null && typeof data != "undefined") {
+        moment.locale("{{ app.request.locale }}");
+        return moment.unix(data).fromNow();
     } else {
         return null;
     }


### PR DESCRIPTION
I've added two functions to print a datetime in human readable format from timestamp.
They are `render_datetime_from_timestamp` and `render_timeago_from_timestamp`.

i.e.

```php
...
->add('timestamp', 'datetime', array(
    'title' => 'Date',
    'render' => 'render_datetime_from_timestamp',
    'date_format' => 'DD/MM/YYYY HH:mm',
  ))
...
```
I hope that these functions are welcome. Enjoy!