### PR TITLE
Set required topActions option actions

### DIFF
--- a/Tests/Datatables/PostDatatable.php
+++ b/Tests/Datatables/PostDatatable.php
@@ -26,6 +26,10 @@ class PostDatatable extends AbstractDatatableView
      */
     public function buildDatatable(array $options = array())
     {
+        $this->topActions->set(array(
+            'actions' => array()
+        ));
+
         $this->features->set(array(
             'scroll_x' => true,
             'extensions' => array(


### PR DESCRIPTION
According to [the docs](https://github.com/stwe/DatatablesBundle/blob/master/Resources/doc/setup.md#top-actions-options) and source code, the required top actions option `actions` does not have a default value.

The test there must fail. See: https://travis-ci.org/stwe/DatatablesBundle/builds/134536171