### PR TITLE
Doctrine Embeddables

### DIFF
--- a/Datatable/Data/DatatableQuery.php
+++ b/Datatable/Data/DatatableQuery.php
@@ -298,6 +298,13 @@ class DatatableQuery
 
                 $metadata = $this->metadata;
 
+                // If it's an embedded class, we can query without JOIN
+                if(array_key_exists($parts[0], $metadata->embeddedClasses)) {
+                    $this->selectColumns[$currentAlias][] = $data;
+                    $this->addSearchOrderColumn($key, $currentAlias, $data);
+                    continue;
+                }
+
                 while (count($parts) > 1) {
 
                     $previousPart = $currentPart;


### PR DESCRIPTION
This bundle doesn't handle Doctrine Embeddables correctly. Example entity:

```php
use Doctrine\ORM\Mapping as ORM;

/**
 * @ORM\Entity
 * @ORM\Table
 */
class MyEntity
{
    /**
     * @ORM\Id
     * @ORM\Column(type="integer")
     * @ORM\GeneratedValue(strategy="AUTO")
     */
    private $id;

    /**
     * @ORM\Embedded(class="DateRange")
     */
    private $termPeriod;
}
```

Exception thrown:

`Association name expected, "termPeriod" is not an association. InvalidArgumentException in vendor/doctrine/orm/lib/Doctrine/ORM/Mapping/ClassMetadataInfo.php at line 3044`

I made a start on fixing this issue and there is no more exception being thrown. The JSON output for an entity with an embedded class looks like this:

```json
{
	"draw": 1,
	"recordsTotal": 1,
	"recordsFiltered": 1,
	"data": [{
		"id": 14,
		"termPeriod.startDate": {
			"timezone": {
				"name": "Europe\/London",
				"location": {
					"country_code": "GB",
					"latitude": 51.50833,
					"longitude": -0.12527,
					"comments": ""
				}
			},
			"offset": 3600,
			"timestamp": 1464822000
		},
		"termPeriod.endDate": {
			"timezone": {
				"name": "Europe\/London",
				"location": {
					"country_code": "GB",
					"latitude": 51.50833,
					"longitude": -0.12527,
					"comments": ""
				}
			},
			"offset": 3600,
			"timestamp": 1466031600
		},
	}]
}
```

However, because of the way datatables uses dot notation for the `columns.data` option, it won't map the result correctly:

> `.` - Dotted Javascript notation. Just as you use a `.` in Javascript to read from nested objects, so to can the options specified in `data`. For example: `browser.version` or `browser.name`. If your object parameter name contains a period, use `\\` to escape it - i.e. `first\\.name`.

– Source: https://datatables.net/reference/option/columns.data

Not sure where to go from here.