### PR TITLE
Added support for embeddables

### DIFF
--- a/Datatable/Column/ColumnBuilder.php
+++ b/Datatable/Column/ColumnBuilder.php
@@ -77,6 +77,12 @@ class ColumnBuilder implements ColumnBuilderInterface
         /**
          * @var AbstractColumn $column
          */
+         
+        // Support embeddables forcing the two backslashes in the column name
+        if (strpos($data, '\\') !== false) {
+            $data = str_replace('\\', '\\\\', $data);
+        }
+         
         $column = ColumnFactory::createColumnByAlias($alias);
         $column->setTableName($this->tableName);
         $column->setData($data);

--- a/Datatable/Data/DatatableQuery.php
+++ b/Datatable/Data/DatatableQuery.php
@@ -289,33 +289,42 @@ class DatatableQuery
         foreach ($this->columns as $key => $column) {
             $data = $column->getDql();
 
+            $currentPart = $this->tableName;
+            $currentAlias = $currentPart;
+
+            $metadata = $this->metadata;
+
             if (true === $this->isSelectColumn($data)) {
+                $parts = explode('\\.', $data);
 
-                $parts = explode('.', $data);
+                if (count($parts) > 1) {
+                    // If it's an embedded class, we can query without JOIN
+                    if (array_key_exists($parts[0], $metadata->embeddedClasses)) {
+                        $this->selectColumns[$currentAlias][] = str_replace('\\', '', $data);
+                        $this->addSearchOrderColumn($key, $currentAlias, $data);
+                        continue;
+                    }
+                } else {
+                    $parts = explode('.', $data);
 
-                $currentPart = $this->tableName;
-                $currentAlias = $currentPart;
+                    while (count($parts) > 1) {
+                        $previousPart = $currentPart;
+                        $previousAlias = $currentAlias;
 
-                $metadata = $this->metadata;
+                        $currentPart = array_shift($parts);
+                        $currentAlias = ($previousPart == $this->tableName ? '' : $previousPart.'_') . $currentPart; // This condition keeps stable queries callbacks
 
-                while (count($parts) > 1) {
+                        if (!array_key_exists($previousAlias.'.'.$currentPart, $this->joins)) {
+                            $this->joins[$previousAlias.'.'.$currentPart] = $currentAlias;
+                        }
 
-                    $previousPart = $currentPart;
-                    $previousAlias = $currentAlias;
-
-                    $currentPart = array_shift($parts);
-                    $currentAlias = ($previousPart == $this->tableName ? '' : $previousPart.'_') . $currentPart; // This condition keeps stable queries callbacks
-
-                    if (!array_key_exists($previousAlias.'.'.$currentPart, $this->joins)) {
-                        $this->joins[$previousAlias.'.'.$currentPart] = $currentAlias;
+                        $metadata = $this->setIdentifierFromAssociation($currentAlias, $currentPart, $metadata);
                     }
 
-                    $metadata = $this->setIdentifierFromAssociation($currentAlias, $currentPart, $metadata);
+                    $this->selectColumns[$currentAlias][] = $this->getIdentifier($metadata);
+                    $this->selectColumns[$currentAlias][] = $parts[0];
+                    $this->addSearchOrderColumn($key, $currentAlias, $parts[0]);
                 }
-
-                $this->selectColumns[$currentAlias][] = $this->getIdentifier($metadata);
-                $this->selectColumns[$currentAlias][] = $parts[0];
-                $this->addSearchOrderColumn($key, $currentAlias, $parts[0]);
             } else {
                 $this->orderColumns[] = null;
                 $this->searchColumns[] = null;

--- a/Datatable/Data/DatatableQuery.php
+++ b/Datatable/Data/DatatableQuery.php
@@ -295,7 +295,7 @@ class DatatableQuery
             $metadata = $this->metadata;
 
             if (true === $this->isSelectColumn($data)) {
-                $parts = explode('\\.', $data);
+                $parts = explode('\\\\.', $data);
 
                 if (count($parts) > 1) {
                     // If it's an embedded class, we can query without JOIN

--- a/Resources/doc/columns.md
+++ b/Resources/doc/columns.md
@@ -66,7 +66,7 @@ $this->columnBuilder
 ;
 ```
 
-For embeddables:
+For Doctrine Embeddables:
 
 ``` php
 $this->columnBuilder

--- a/Resources/doc/columns.md
+++ b/Resources/doc/columns.md
@@ -65,6 +65,16 @@ $this->columnBuilder
     ))
 ;
 ```
+
+For embeddables:
+
+``` php
+$this->columnBuilder
+    ->add('credentials.username', 'column', array(
+        'title' => 'Username'
+    ))
+;
+```
 ___
 
 ## 2. Array column

--- a/Resources/doc/columns.md
+++ b/Resources/doc/columns.md
@@ -70,7 +70,7 @@ For embeddables:
 
 ``` php
 $this->columnBuilder
-    ->add('credentials.username', 'column', array(
+    ->add('credentials\\.username', 'column', array(
         'title' => 'Username'
     ))
 ;


### PR DESCRIPTION
This is an improvement based on the pull request discussed [here](https://github.com/stwe/DatatablesBundle/pull/391) from foaly-nr1

In order to add an embedded column in a datatable, it should be separated with `\\.`

example: 

```php
$this->columnBuilder
            ->add('id', 'column', array(
                'visible' => false,
            ))
            ->add('checkbox', 'virtual', array(
                'title' => '',
            ))
            ->add('credentials\\.username', 'column', array( // this is an embeddable named "Credentials"
                'title' => 'Username',
            ))
;
```