### PR TITLE
Prevent duplicate query

### DIFF
--- a/Datatable/Data/DatatableQuery.php
+++ b/Datatable/Data/DatatableQuery.php
@@ -769,9 +769,15 @@ class DatatableQuery
 
         $outputHeader = array(
             'draw' => (int) $this->requestParams['draw'],
-            'recordsTotal' => (int) $this->getCountAllResults($this->rootEntityIdentifier),
-            'recordsFiltered' => (int) $this->getCountFilteredResults($this->rootEntityIdentifier, $buildQuery)
+            'recordsTotal' => (int) $this->getCountAllResults($this->rootEntityIdentifier)
         );
+
+        if ($this->getQuery()->getDQLPart('where') === null) {
+            $outputHeader['recordsFiltered'] = $outputHeader['recordsTotal'];
+            
+        } else {
+            $outputHeader['recordsFiltered'] =  (int) $this->getCountFilteredResults($this->rootEntityIdentifier);
+        }
 
         $fullOutput = array_merge($outputHeader, $formatter->getOutput());
         $fullOutput = $this->applyResponseCallbacks($fullOutput);


### PR DESCRIPTION
If there are no WHERE statements, then `recordsTotal === recordsFiltered`. In that case, there is no need to run two (exactly the same) queries.