### PR TITLE
Remove `add_if` from documentation

### DIFF
--- a/Resources/doc/columns.md
+++ b/Resources/doc/columns.md
@@ -36,7 +36,6 @@ SgDatatablesBundle:Column:column.html.twig
 | visible     | boolean        | true                   |
 | width       | string         | ''                     |
 | filter      | array          | array('text', array()) |
-| add_if      | Closure        | null                   |
 | default     | string         | ''                     |
 | editable    | boolean        | false                  |
 | editable_if | Closure        | null                   |
@@ -50,9 +49,6 @@ $this->columnBuilder
         'searchable' => false,
         'orderable' => false,
         'default' => 'default title value',
-        'add_if' => function() {
-            return ($this->authorizationChecker->isGranted('ROLE_ADMIN'));
-        },
     ))
 ;
 ```
@@ -104,7 +100,6 @@ SgDatatablesBundle:Column:array.html.twig
 | visible              | boolean        | true                   |          |
 | width                | string         | ''                     |          |
 | filter               | array          | array('text', array()) |          |
-| add_if               | Closure        | null                   |          |
 | default              | string         | ''                     |          |
 | data                 | string         |                        | required |
 | count                | boolean        | false                  |          |
@@ -206,7 +201,6 @@ SgDatatablesBundle:Column:boolean.html.twig
 | true_label  | string         | ''                    |
 | false_label | string         | ''                    |
 | filter      | array          | see the below example |
-| add_if      | Closure        | null                  |
 | editable    | boolean        | false                 |
 | editable_if | Closure        | null                  |
 
@@ -252,7 +246,6 @@ SgDatatablesBundle:Column:datetime.html.twig
 | visible     | boolean        | true                   |
 | width       | string         | ''                     |
 | filter      | array          | array('text', array()) |
-| add_if      | Closure        | null                   |
 | date_format | string         | 'lll'                  |
 | editable    | boolean        | false                  |
 | editable_if | Closure        | null                   |
@@ -293,7 +286,6 @@ SgDatatablesBundle:Column:timeago.html.twig
 | visible              | boolean        | true                   |
 | width                | string         | ''                     |
 | filter               | array          | array('text', array()) |
-| add_if               | Closure        | null                   |
 
 ### Example
 
@@ -327,7 +319,6 @@ SgDatatablesBundle:Column:action.html.twig
 | width      | string      | ''      |          |
 | start_html | string      | ''      |          |
 | end_html   | string      | ''      |          |
-| add_if     | Closure     | null    |          |
 | actions    | array       |         | required |
 
 ### Action options
@@ -351,9 +342,6 @@ $this->columnBuilder
         'title' => 'Actions',
         'start_html' => '<div class="wrapper_example_class">',
         'end_html' => '</div>',
-        'add_if' => function() {
-            return ($this->authorizationChecker->isGranted('ROLE_ADMIN'));
-        },
         'actions' => array( // required option
             array(
                 'route' => 'post_edit',
@@ -414,7 +402,6 @@ SgDatatablesBundle:Column:multiselect.html.twig
 | width              | string      | ''      |          |
 | start_html         | string      | ''      |          |
 | end_html           | string      | ''      |          |
-| add_if             | Closure     | null    |          |
 | actions            | array       |         | required |
 | attributes         | array       | array() |          |
 | value              | string      | 'id'    |          |
@@ -446,9 +433,6 @@ $this->getColumnBuilder()
             'class' => 'testclass',
             'name' => 'testname',
         ),
-        'add_if' => function() {
-            return ($this->authorizationChecker->isGranted('ROLE_ADMIN'));
-        },
         'render_checkbox_if' => function($row) {
             return ($row['public'] == true);
         },
@@ -578,7 +562,6 @@ SgDatatablesBundle:Column:image.html.twig
 | visible                  | boolean        | true                   |          |
 | width                    | string         | ''                     |          |
 | filter                   | array          | array('text', array()) |          |
-| add_if                   | Closure        | null                   |          |
 | imagine_filter           | string         | ''                     |          |
 | imagine_filter_enlarged  | null or string | null                   |          |
 | relative_path            | string         |                        | required |
@@ -702,7 +685,6 @@ SgDatatablesBundle:Column:image.html.twig
 | visible                 | boolean        | true                   |          |
 | width                   | string         | ''                     |          |
 | filter                  | array          | array('text', array()) |          |
-| add_if                  | Closure        | null                   |          |
 | imagine_filter          | string         |                        | required |
 | imagine_filter_enlarged | null or string | null                   |          |
 | relative_path           | string         |                        | required |
@@ -752,7 +734,6 @@ SgDatatablesBundle:Column:progress_bar.html.twig
 | visible              | boolean        | true                  |
 | width                | string         | ''                    |
 | filter               | array          | see the below example |
-| add_if               | Closure        | null                  |
 | bar_classes          | string         | ''                    |
 | value_min            | string         | '0'                   |
 | value_max            | string         | '100'                 |


### PR DESCRIPTION
The column option `add_if` does not exist and throws an error on my system e.g.: `The option "add_if" does not exist. Defined options are: "actions", "class", "end_html", "name", "padding", "start_html", "title", "type", "visible", "width".`