### PR TITLE
Allow repeated overriding of view options

### DIFF
--- a/Datatable/View/AbstractViewOptions.php
+++ b/Datatable/View/AbstractViewOptions.php
@@ -29,7 +29,7 @@ abstract class AbstractViewOptions implements OptionsInterface
      *
      * @var array
      */
-    protected $options;
+    protected $options = array();
 
     /**
      * @var null|OptionsResolver
@@ -45,9 +45,7 @@ abstract class AbstractViewOptions implements OptionsInterface
      */
     public function __construct()
     {
-        $this->options = array();
-        $this->nestedOptionsResolver = null;
-        $this->set($this->options);
+        $this->set(array());
     }
 
     //-------------------------------------------------

--- a/Datatable/View/AbstractViewOptions.php
+++ b/Datatable/View/AbstractViewOptions.php
@@ -45,7 +45,7 @@ abstract class AbstractViewOptions implements OptionsInterface
      */
     public function __construct()
     {
-        $this->set(array());
+        self::callingSettersWithOptions($this->options, $this);
     }
 
     //-------------------------------------------------

--- a/Datatable/View/Ajax.php
+++ b/Datatable/View/Ajax.php
@@ -43,6 +43,15 @@ class Ajax extends AbstractViewOptions
      */
     protected $pipeline;
 
+    /**
+     * {@inheritdoc}
+     */
+    protected $options = array(
+        'url' => '',
+        'type' => 'GET',
+        'pipeline' => 0
+    );
+
     //-------------------------------------------------
     // OptionsInterface
     //-------------------------------------------------
@@ -52,11 +61,7 @@ class Ajax extends AbstractViewOptions
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
-            'url' => '',
-            'type' => 'GET',
-            'pipeline' => 0
-        ));
+        $resolver->setDefaults($this->options);
 
         $resolver->setAllowedTypes('url', 'string');
         $resolver->setAllowedTypes('type', 'string');

--- a/Datatable/View/Callbacks.php
+++ b/Datatable/View/Callbacks.php
@@ -118,6 +118,26 @@ class Callbacks extends AbstractViewOptions
      */
     protected $stateSaveParams;
 
+    /**
+     * {@inheritdoc}
+     */
+    protected $options = array(
+        'created_row' => array(),
+        'draw_callback' => array(),
+        'footer_callback' => array(),
+        'format_number' => array(),
+        'header_callback' => array(),
+        'info_callback' => array(),
+        'init_complete' => array(),
+        'pre_draw_callback' => array(),
+        'row_callback' => array(),
+        'state_load_callback' => array(),
+        'state_loaded' => array(),
+        'state_load_params' => array(),
+        'state_save_callback' => array(),
+        'state_save_params' => array(),
+    );
+
     //-------------------------------------------------
     // OptionsInterface
     //-------------------------------------------------
@@ -127,22 +147,7 @@ class Callbacks extends AbstractViewOptions
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
-            'created_row' => array(),
-            'draw_callback' => array(),
-            'footer_callback' => array(),
-            'format_number' => array(),
-            'header_callback' => array(),
-            'info_callback' => array(),
-            'init_complete' => array(),
-            'pre_draw_callback' => array(),
-            'row_callback' => array(),
-            'state_load_callback' => array(),
-            'state_loaded' => array(),
-            'state_load_params' => array(),
-            'state_save_callback' => array(),
-            'state_save_params' => array(),
-        ));
+        $resolver->setDefaults($this->options);
 
         $resolver->setAllowedTypes('created_row', 'array');
         $resolver->setAllowedTypes('draw_callback', 'array');

--- a/Datatable/View/Events.php
+++ b/Datatable/View/Events.php
@@ -125,6 +125,27 @@ class Events extends AbstractViewOptions
      */
     protected $xhr;
 
+    /**
+     * {@inheritdoc}
+     */
+    protected $options = array(
+        'column_sizing' => array(),
+        'column_visibility' => array(),
+        'destroy' => array(),
+        'error' => array(),
+        'length' => array(),
+        'order' => array(),
+        'page' => array(),
+        'pre_init' => array(),
+        'pre_xhr' => array(),
+        'processing' => array(),
+        'search' => array(),
+        'state_loaded' => array(),
+        'state_load_params' => array(),
+        'state_save_params' => array(),
+        'xhr' => array(),
+    );
+
     //-------------------------------------------------
     // OptionsInterface
     //-------------------------------------------------
@@ -134,23 +155,7 @@ class Events extends AbstractViewOptions
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
-            'column_sizing' => array(),
-            'column_visibility' => array(),
-            'destroy' => array(),
-            'error' => array(),
-            'length' => array(),
-            'order' => array(),
-            'page' => array(),
-            'pre_init' => array(),
-            'pre_xhr' => array(),
-            'processing' => array(),
-            'search' => array(),
-            'state_loaded' => array(),
-            'state_load_params' => array(),
-            'state_save_params' => array(),
-            'xhr' => array(),
-        ));
+        $resolver->setDefaults($this->options);
 
         $resolver->setAllowedTypes('column_sizing', 'array');
         $resolver->setAllowedTypes('column_visibility', 'array');

--- a/Datatable/View/Features.php
+++ b/Datatable/View/Features.php
@@ -133,6 +133,28 @@ class Features extends AbstractViewOptions
      */
     protected $highlightColor;
 
+    /**
+     * {@inheritdoc}
+     */
+    protected $options = array(
+        'auto_width' => true,
+        'defer_render' => false,
+        'info' => true,
+        'jquery_ui' => false,
+        'length_change' => true,
+        'ordering' => true,
+        'paging' => true,
+        'processing' => true,
+        'scroll_x' => false,
+        'scroll_y' => '',
+        'searching' => true,
+        'state_save' => false,
+        'delay' => 0,
+        'extensions' => array(),
+        'highlight' => false,
+        'highlight_color' => 'red'
+    );
+
     //-------------------------------------------------
     // OptionsInterface
     //-------------------------------------------------
@@ -142,24 +164,7 @@ class Features extends AbstractViewOptions
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
-            'auto_width' => true,
-            'defer_render' => false,
-            'info' => true,
-            'jquery_ui' => false,
-            'length_change' => true,
-            'ordering' => true,
-            'paging' => true,
-            'processing' => true,
-            'scroll_x' => false,
-            'scroll_y' => '',
-            'searching' => true,
-            'state_save' => false,
-            'delay' => 0,
-            'extensions' => array(),
-            'highlight' => false,
-            'highlight_color' => 'red'
-        ));
+        $resolver->setDefaults($this->options);
 
         $resolver->setAllowedTypes('auto_width', 'bool');
         $resolver->setAllowedTypes('defer_render', 'bool');

--- a/Datatable/View/Options.php
+++ b/Datatable/View/Options.php
@@ -158,6 +158,31 @@ class Options extends AbstractViewOptions
      */
     protected $forceDom;
 
+    /**
+     * {@inheritdoc}
+     */
+    protected $options = array(
+        'display_start' => 0,
+        'defer_loading' => -1,
+        'dom' => 'lfrtip',
+        'length_menu' => array(10, 25, 50, 100),
+        'order_classes' => true,
+        'order' => array(array(0, 'asc')),
+        'order_multi' => true,
+        'page_length' => 10,
+        'paging_type' => Style::FULL_NUMBERS_PAGINATION,
+        'renderer' => '',
+        'scroll_collapse' => false,
+        'search_delay' => 0,
+        'state_duration' => 7200,
+        'stripe_classes' => array(),
+        'class' => Style::BASE_STYLE,
+        'individual_filtering' => false,
+        'individual_filtering_position' => 'head',
+        'use_integration_options' => false,
+        'force_dom' => false
+    );
+
     //-------------------------------------------------
     // OptionsInterface
     //-------------------------------------------------
@@ -184,27 +209,7 @@ class Options extends AbstractViewOptions
      */
     public function configureOptions(OptionsResolver $resolver)
     {
-        $resolver->setDefaults(array(
-            'display_start' => 0,
-            'defer_loading' => -1,
-            'dom' => 'lfrtip',
-            'length_menu' => array(10, 25, 50, 100),
-            'order_classes' => true,
-            'order' => array(array(0, 'asc')),
-            'order_multi' => true,
-            'page_length' => 10,
-            'paging_type' => Style::FULL_NUMBERS_PAGINATION,
-            'renderer' => '',
-            'scroll_collapse' => false,
-            'search_delay' => 0,
-            'state_duration' => 7200,
-            'stripe_classes' => array(),
-            'class' => Style::BASE_STYLE,
-            'individual_filtering' => false,
-            'individual_filtering_position' => 'head',
-            'use_integration_options' => false,
-            'force_dom' => false
-        ));
+        $resolver->setDefaults($this->options);
 
         $resolver->setAllowedTypes('display_start', 'int');
         $resolver->setAllowedTypes('defer_loading', 'int');
@@ -374,7 +379,7 @@ class Options extends AbstractViewOptions
                 throw new \Exception('setOrder(): Invalid array format.');
             }
         }
-        
+
         $this->order = $order;
 
         return $this;

--- a/Datatable/View/TopActions.php
+++ b/Datatable/View/TopActions.php
@@ -64,6 +64,15 @@ class TopActions extends AbstractViewOptions
         $this->nestedOptionsResolver = null;
     }
 
+    /**
+     * {@inheritdoc}
+     */
+    protected $options = array(
+        'start_html' => '',
+        'end_html' => '',
+        'add_if' => null
+    );
+
     //-------------------------------------------------
     // OptionsInterface
     //-------------------------------------------------
@@ -75,11 +84,7 @@ class TopActions extends AbstractViewOptions
     {
         $resolver->setRequired(array('actions'));
 
-        $resolver->setDefaults(array(
-            'start_html' => '',
-            'end_html' => '',
-            'add_if' => null
-        ));
+        $resolver->setDefaults($this->options);
 
         $resolver->setAllowedTypes('start_html', 'string');
         $resolver->setAllowedTypes('end_html', 'string');

--- a/Datatable/View/TopActions.php
+++ b/Datatable/View/TopActions.php
@@ -51,19 +51,6 @@ class TopActions extends AbstractViewOptions
      */
     protected $actions;
 
-    //-------------------------------------------------
-    // Ctor.
-    //-------------------------------------------------
-
-    /**
-     * Ctor.
-     */
-    public function __construct()
-    {
-        $this->options = array();
-        $this->nestedOptionsResolver = null;
-    }
-
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
This is to resolve https://github.com/stwe/DatatablesBundle/issues/388.

Following recent changes in this bundle, I re-did my previous pull request https://github.com/stwe/DatatablesBundle/pull/389. It involves less changes and passes all tests. Fully backwards compatible.
