### PR TITLE
Call buildDatatable() in DatatableTest

### DIFF
--- a/Tests/DatatableTest.php
+++ b/Tests/DatatableTest.php
@@ -41,5 +41,7 @@ class DatatableTest extends \PHPUnit_Framework_TestCase
         $table = new $tableClass($authorizationChecker, $securityToken, $translator, $router, $em);
 
         $this->assertEquals('post_datatable', $table->getName());
+
+        $table->buildDatatable();
     }
 }

--- a/Tests/Datatables/PostDatatable.php
+++ b/Tests/Datatables/PostDatatable.php
@@ -42,7 +42,7 @@ class PostDatatable extends AbstractDatatableView
         ));
 
         $this->ajax->set(array(
-            'url' => $this->router->generate('post_results'),
+            'url' => '',
             'type' => 'GET'
         ));
 
@@ -54,7 +54,7 @@ class PostDatatable extends AbstractDatatableView
 
         $this->columnBuilder
             ->add('id', 'column', array(
-                'id' => 'Id',
+                'title' => 'Id',
             ))
             ->add('title', 'column', array(
                 'title' => 'Title',


### PR DESCRIPTION
1. Generating a route `post_results` will fail as there is no such route in this bundle.
2. The option `id` does not exist. This seems to be a typo.

The errors were not previously thrown as `buildDatatable()` was never called.