### PR TITLE
Update DatatableQuery.php

### DIFF
--- a/Datatable/Data/DatatableQuery.php
+++ b/Datatable/Data/DatatableQuery.php
@@ -550,7 +550,13 @@ class DatatableQuery
                 if (true === $this->isSearchColumn($column)) {
                     $filter = $column->getFilter();
                     $searchField = $this->searchColumns[$key];
+                    
+                    if (array_key_exists($key, $this->requestParams['columns']) === false) {
+                        continue;
+                    }
+                    
                     $searchValue = $this->requestParams['columns'][$key]['search']['value'];
+                    
                     if ('' != $searchValue && 'null' != $searchValue) {
                         if (true === $this->isPostgreSQLConnection) {
                             $searchField = $this->cast($searchField, $column);


### PR DESCRIPTION
This update prevents an `undefined index` error during unit testing a symfony component of mine:

```
Uncaught PHP Exception PHPUnit_Framework_Error_Notice: "Undefined index: search" at
  ...vendor\sg\datatablesbundle\Sg\DatatablesBundle\Datatable\Data\DatatableQuery.php line 553 
  {"exception":"[object] (PHPUnit_Framework_Error_Notice(code: 8): Undefined index: search at 
  ...\\vendor\\sg\\datatablesbundle\\Sg\\DatatablesBundle\\Datatable\\Data\\DatatableQuery.php:553)"} []
```