### PR TITLE
Update DatatableQuery.php - resetDQLPart 'groupBy'

### DIFF
--- a/Datatable/Data/DatatableQuery.php
+++ b/Datatable/Data/DatatableQuery.php
@@ -638,7 +638,11 @@ class DatatableQuery
         $this->setLeftJoins($qb);
         $this->setWhereAllCallback($qb);
 
-        return (int) $qb->getQuery()->getSingleScalarResult();
+        if (count($qb->getDQLPart('groupBy')) > 0) {
+            return count($qb->getQuery()->getResult());
+        } else {
+            return (int) $qb->getQuery()->getSingleScalarResult();
+        }
     }
 
     /**
@@ -669,6 +673,8 @@ class DatatableQuery
                 ->select('count(distinct ' . $this->tableName . '.' . $rootEntityIdentifier . ')');
             if (true === $this->isPostgreSQLConnection) {
                 $this->qb->groupBy($this->tableName . '.' . $rootEntityIdentifier);
+                return count($this->qb->getQuery()->getResult());
+            } elseif (count($this->qb->getDQLPart('groupBy')) > 0) {
                 return count($this->qb->getQuery()->getResult());
             } else {
                 return (int) $this->qb->getQuery()->getSingleScalarResult();


### PR DESCRIPTION
I'm able to manipulate a datatable query by calling:

``` php
$sgQuery = $this->get('sg_datatables.query');
$query = $sgQuery->getQueryFrom(/* get datatable */);
$query->buildQuery();

$query->setQuery( /* manipulated query */ );
```

If I add a `groupBy` into my manipulated query, datatable throws me an error on counting the overall result (`NonUniqueResultException`).

With this fix, I'm able to properly count the filtered results using a `groupBy` statement.
