### PR TITLE
Cast strings to numbers to properly sort them in the backend.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.c9/
+.idea/
+
+vendor/

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ sudo: false
 php:
   - 5.3
   - 5.4
+  - 5.5
   - 5.6
   - 7.0
   - hhvm
+  - nightly
 
 cache:
   directories:
@@ -26,8 +28,11 @@ matrix:
       env: SYMFONY_VERSION=2.8.*
     - php: 5.6
       env: SYMFONY_VERSION=3.0.*
+    - php: 5.6
+      env: SYMFONY_VERSION=3.1.*
   allow_failures:
     - php: hhvm
+    - php: nightly
 
 before_install:
   - composer selfupdate

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,16 @@ matrix:
       env: SYMFONY_VERSION=3.0.*
     - php: 5.6
       env: SYMFONY_VERSION=3.1.*
+    - php: 7
+      env: SYMFONY_VERSION=2.6.*
+    - php: 7
+      env: SYMFONY_VERSION=2.7.*
+    - php: 7
+      env: SYMFONY_VERSION=2.8.*
+    - php: 7
+      env: SYMFONY_VERSION=3.0.*
+    - php: 7
+      env: SYMFONY_VERSION=3.1.*
   allow_failures:
     - php: hhvm
     - php: nightly

--- a/Datatable/Data/DatatableQuery.php
+++ b/Datatable/Data/DatatableQuery.php
@@ -592,15 +592,48 @@ class DatatableQuery
                 $requestColumn = $this->requestParams['columns'][$columnIdx];
 
                 if ('true' == $requestColumn['orderable']) {
-                    $this->qb->addOrderBy(
-                        $this->orderColumns[$columnIdx],
-                        $this->requestParams['order'][$i]['dir']
-                    );
+                    $this->prepareOrderBy($columnIdx, $i);
                 }
             }
         }
 
         return $this;
+    }
+
+    /**
+     * Prepare order by statements. In some case we want to order string/varchar database fields as numbers.
+     *
+     * @param int $columnIdx
+     * @param int $i
+     *
+     * @see http://stackoverflow.com/questions/22993336/how-to-order-varchar-as-int-in-symfony2-doctrine2#23071353
+     */
+    private function prepareOrderBy($columnIdx, $i)
+    {
+        $columnType = $this->columns[$columnIdx]->getType();
+        $columnName = $this->orderColumns[$columnIdx];
+        $orderDirection = $this->requestParams['order'][$i]['dir'];
+
+        switch ($columnType) {
+            // Order by number which is stored as string/varchar in the database.
+            case 'num':
+            case 'int':
+            case 'integer':
+                $tempOrderColumnName = str_replace('.', '_', $columnName) . '_order_as_int';
+
+                $this->qb
+                    ->addSelect(sprintf(
+                        'ABS(%s) AS HIDDEN %s',
+                        $columnName,
+                        $tempOrderColumnName
+                    ))
+                    ->addOrderBy($tempOrderColumnName, $orderDirection);
+                break;
+
+            default:
+                $this->qb->addOrderBy($columnName, $orderDirection);
+                break;
+        }
     }
 
     /**
@@ -662,16 +695,19 @@ class DatatableQuery
 
             return (int) $qb->getQuery()->getSingleScalarResult();
         } else {
-            $this
-                ->qb
+            $qb = clone $this->qb;
+            
+            $qb
+                // Reset orderBy part - where might be a special orderBy syntax previously set to order strings as numbers.
+                ->resetDQLPart('orderBy')
                 ->setFirstResult(null)
                 ->setMaxResults(null)
                 ->select('count(distinct ' . $this->tableName . '.' . $rootEntityIdentifier . ')');
             if (true === $this->isPostgreSQLConnection) {
-                $this->qb->groupBy($this->tableName . '.' . $rootEntityIdentifier);
-                return count($this->qb->getQuery()->getResult());
+                $qb->groupBy($this->tableName . '.' . $rootEntityIdentifier);
+                return count($qb->getQuery()->getResult());
             } else {
-                return (int) $this->qb->getQuery()->getSingleScalarResult();
+                return (int) $qb->getQuery()->getSingleScalarResult();
             }
         }
     }

--- a/Datatable/Data/DatatableQuery.php
+++ b/Datatable/Data/DatatableQuery.php
@@ -835,7 +835,7 @@ class DatatableQuery
     private function getMetadata($entity)
     {
         try {
-            $metadata = $this->em->getMetadataFactory()->getMetadataFor($entity);
+            $metadata = $this->em->getClassMetadata($entity);
         } catch (MappingException $e) {
             throw new Exception('getMetadata(): Given object ' . $entity . ' is not a Doctrine Entity.');
         }

--- a/Tests/BaseDatatablesTestCase.php
+++ b/Tests/BaseDatatablesTestCase.php
@@ -50,14 +50,6 @@ class BaseDatatablesTestCase extends \PHPUnit_Framework_TestCase
             ->method('getIdentifierFieldNames')
             ->willReturn(array());
 
-        $metadataFactory = $this->getMockBuilder('Doctrine\Common\Persistence\Mapping\ClassMetadataFactory')
-            ->getMock();
-
-        $metadataFactory
-            ->expects($this->any())
-            ->method('getMetadataFor')
-            ->willReturn($classMetadata);
-
         $driver = $this->getMockBuilder('Doctrine\DBAL\Driver')
             ->getMock();
 
@@ -73,12 +65,16 @@ class BaseDatatablesTestCase extends \PHPUnit_Framework_TestCase
         $em = $this->getMockBuilder('Doctrine\ORM\EntityManagerInterface')
             ->getMock();
 
-        $queryBuilder = new \Doctrine\ORM\QueryBuilder($em);
+        $emInstance = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $queryBuilder = new \Doctrine\ORM\QueryBuilder($emInstance);
 
         $em
             ->expects($this->any())
-            ->method('getMetadataFactory')
-            ->willReturn($metadataFactory);
+            ->method('getClassMetadata')
+            ->willReturn($classMetadata);
 
         $em
             ->expects($this->any())

--- a/Tests/BaseDatatablesTestCase.php
+++ b/Tests/BaseDatatablesTestCase.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Sg\DatatablesBundle\Tests;
+
+/**
+ * Class BaseDatatablesTestCase
+ *
+ * @package Sg\DatatablesBundle\Tests
+ */
+class BaseDatatablesTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $tableClass
+     *
+     * @return Datatables\PostDatatable
+     */
+    protected function createDummyDatatable($tableClass = 'Sg\DatatablesBundle\Tests\Datatables\PostDatatable')
+    {
+        $authorizationChecker = $this->getMockBuilder('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')
+            ->getMock();
+
+        $securityToken = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')
+            ->getMock();
+
+        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')
+            ->getMock();
+
+        $router = $this->getMockBuilder('Symfony\Component\Routing\RouterInterface')
+            ->getMock();
+
+        $em = $this->getEntityManagerMock();
+
+        /** @var \Sg\DatatablesBundle\Tests\Datatables\PostDatatable $table */
+        $table = new $tableClass($authorizationChecker, $securityToken, $translator, $router, $em);
+
+        return $table;
+    }
+
+    /**
+     * @return \Doctrine\ORM\EntityManagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected function getEntityManagerMock()
+    {
+        $classMetadata = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $classMetadata
+            ->expects($this->any())
+            ->method('getIdentifierFieldNames')
+            ->willReturn(array());
+
+        $metadataFactory = $this->getMockBuilder('Doctrine\Common\Persistence\Mapping\ClassMetadataFactory')
+            ->getMock();
+
+        $metadataFactory
+            ->expects($this->any())
+            ->method('getMetadataFor')
+            ->willReturn($classMetadata);
+
+        $driver = $this->getMockBuilder('Doctrine\DBAL\Driver')
+            ->getMock();
+
+        $connection = $this->getMockBuilder('Doctrine\DBAL\Connection')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $connection
+            ->expects($this->any())
+            ->method('getDriver')
+            ->willReturn($driver);
+
+        $em = $this->getMockBuilder('Doctrine\ORM\EntityManagerInterface')
+            ->getMock();
+
+        $queryBuilder = new \Doctrine\ORM\QueryBuilder($em);
+
+        $em
+            ->expects($this->any())
+            ->method('getMetadataFactory')
+            ->willReturn($metadataFactory);
+
+        $em
+            ->expects($this->any())
+            ->method('getConnection')
+            ->willReturn($connection);
+
+        $em
+            ->expects($this->any())
+            ->method('createQueryBuilder')
+            ->willReturn($queryBuilder);
+
+        return $em;
+    }
+
+
+    //-------------------------------------------------
+    // Helper methods to access private properties.
+    //-------------------------------------------------
+
+    /**
+     * @param object $object
+     * @param string $propertyName
+     *
+     * @return \ReflectionMethod
+     */
+    protected function getPrivateProperty($object, $propertyName)
+    {
+        $reflector = new \ReflectionClass($object);
+        $property = $reflector->getProperty($propertyName);
+        $property->setAccessible(true);
+
+        return $property->getValue($object);
+    }
+
+    /**
+     * @param object $object
+     * @param string $propertyName
+     * @param mixed  $propertyValue
+     */
+    protected function setPrivateProperty($object, $propertyName, $propertyValue)
+    {
+        $reflector = new \ReflectionClass($object);
+        $property = $reflector->getProperty($propertyName);
+        $property->setAccessible(true);
+        $property->setValue($object, $propertyValue);
+    }
+
+    /**
+     * @param object $object
+     * @param string $propertyName
+     * @param array  $value
+     */
+    protected function extendPrivateArrayProperty($object, $propertyName, array $value)
+    {
+        $data = (array)$this->getPrivateProperty($object, $propertyName);
+        $data = array_merge_recursive($data, $value);
+        $this->setPrivateProperty($object, $propertyName, $data);
+    }
+
+    /**
+     * @param object|string $classNameOrObject
+     * @param string        $methodName
+     *
+     * @return \ReflectionMethod
+     */
+    protected function getPrivateMethod($classNameOrObject, $methodName)
+    {
+        $reflector = new \ReflectionClass($classNameOrObject);
+        $method = $reflector->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method;
+    }
+
+    /**
+     * @param object $object
+     * @param string $methodName
+     * @param array  $args
+     *
+     * @return mixed
+     */
+    protected function invokePrivateMethod($object, $methodName, array $args = array())
+    {
+        return $this
+            ->getPrivateMethod($object, $methodName)
+            ->invokeArgs($object, $args);
+    }
+}

--- a/Tests/Datatable/Data/DatatableQueryTest.php
+++ b/Tests/Datatable/Data/DatatableQueryTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Sg\DatatablesBundle\Tests\Datatable\Data;
+
+use Sg\DatatablesBundle\Datatable\Data\DatatableQuery;
+use Sg\DatatablesBundle\Tests\BaseDatatablesTestCase;
+
+/**
+ * Class DatatableQueryTest
+ * @package Sg\DatatablesBundle\Tests\Datatable\Data
+ */
+class DatatableQueryTest extends BaseDatatablesTestCase
+{
+    /**
+     * @var DatatableQuery
+     */
+    protected $datatableQuery;
+
+
+    protected function setUp()
+    {
+        $serializer = $this->getMockBuilder('Symfony\Component\Serializer\Serializer')->getMock();
+        $requestParams = array(
+            'search' => array(
+                'value' => '',
+            ),
+            'order' => array(),
+            'columns' => array(),
+        );
+
+        $datatable = $this->createDummyDatatable();
+        $datatable->buildDatatable();
+
+        $configs = array();
+        $twig = $this->getMockBuilder('Twig_Environment')->getMock();
+        $imagineBundle = false;
+        $doctrineExtensions = false;
+        $locale = 'en';
+
+        foreach ($datatable->getColumnBuilder()->getColumns() as $column) {
+            $requestParams['columns'][] = $this->getPrivateProperty($column, 'options');
+        }
+
+        $this->datatableQuery = new DatatableQuery(
+            $serializer,
+            $requestParams,
+            $datatable,
+            $configs,
+            $twig,
+            $imagineBundle,
+            $doctrineExtensions,
+            $locale
+        );
+    }
+
+
+    public function testDummy()
+    {
+        $this->assertTrue(true);
+    }
+
+
+    public function testSetOrderByEmptyRequestParams()
+    {
+        $this->datatableQuery->buildQuery();
+
+        $dqlParts = $this->datatableQuery->getQuery()->getDQLParts();
+
+        $this->assertInternalType('array', $dqlParts);
+        $this->assertEmpty($dqlParts['orderBy']);
+    }
+
+    public function testSetOrderByWithOrderableColumns()
+    {
+        $extendedRequestParams = array(
+            'order' => array(
+                array('column' => 0, 'dir' => 'asc'),
+                array('column' => 1, 'dir' => 'desc'),
+            ),
+        );
+        $this->extendPrivateArrayProperty($this->datatableQuery, 'requestParams', $extendedRequestParams);
+
+        $this->datatableQuery->buildQuery();
+
+        $dqlParts = $this->datatableQuery->getQuery()->getDQLParts();
+
+        $this->assertInternalType('array', $dqlParts);
+        $this->assertNotEmpty($dqlParts['orderBy']);
+
+        $orderByPartOne = $this->getPrivateProperty($dqlParts['orderBy'][0], 'parts');
+        $this->assertContains('id asc', $orderByPartOne[0]);
+
+        $orderByPartTwo = $this->getPrivateProperty($dqlParts['orderBy'][1], 'parts');
+        $this->assertContains('title desc', $orderByPartTwo[0]);
+    }
+
+    public function testSetOrderByWithOrderableColumnsContaingNumbersInStrings()
+    {
+        $extendedRequestParams = array(
+            'order' => array(
+                array('column' => 0, 'dir' => 'asc'),
+                array('column' => 1, 'dir' => 'desc'),
+            ),
+        );
+        $this->extendPrivateArrayProperty($this->datatableQuery, 'requestParams', $extendedRequestParams);
+
+        // Set columns of type number/integer
+        $extendedColumns = $this->getPrivateProperty($this->datatableQuery, 'columns');
+        $extendedColumns[0]->setType('num');
+        $extendedColumns[1]->setType('int');
+        $this->setPrivateProperty($this->datatableQuery, 'columns', $extendedColumns);
+
+        $this->datatableQuery->buildQuery();
+
+        $dqlParts = $this->datatableQuery->getQuery()->getDQLParts();
+
+        $this->assertInternalType('array', $dqlParts);
+        $this->assertNotEmpty($dqlParts['orderBy']);
+
+        $orderByPartOne = $this->getPrivateProperty($dqlParts['orderBy'][0], 'parts');
+        $this->assertContains('id_order_as_int asc', $orderByPartOne[0]);
+
+        $orderByPartTwo = $this->getPrivateProperty($dqlParts['orderBy'][1], 'parts');
+        $this->assertContains('title_order_as_int desc', $orderByPartTwo[0]);
+    }
+}

--- a/Tests/Datatable/Data/DatatableQueryTest.php
+++ b/Tests/Datatable/Data/DatatableQueryTest.php
@@ -21,17 +21,20 @@ class DatatableQueryTest extends BaseDatatablesTestCase
     {
         $serializer = $this->getMockBuilder('Symfony\Component\Serializer\Serializer')->getMock();
         $requestParams = array(
-            'search' => array(
+            'search'  => array(
                 'value' => '',
             ),
-            'order' => array(),
+            'order'   => array(),
             'columns' => array(),
         );
 
         $datatable = $this->createDummyDatatable();
         $datatable->buildDatatable();
 
-        $configs = array();
+        $configs = array(
+            'search_on_non_visible_columns' => false,
+            'translation_query_hints'       => false,
+        );
         $twig = $this->getMockBuilder('Twig_Environment')->getMock();
         $imagineBundle = false;
         $doctrineExtensions = false;
@@ -54,13 +57,198 @@ class DatatableQueryTest extends BaseDatatablesTestCase
     }
 
 
-    public function testDummy()
+    public function testBuildQuery()
     {
-        $this->assertTrue(true);
+        $this->datatableQuery->buildQuery();
+
+        $dqlParts = $this->datatableQuery->getQuery()->getDQLParts();
+
+        $this->assertInternalType('array', $dqlParts);
+        $this->assertNotEmpty($dqlParts);
     }
 
+    public function testBuildQueryCheckFrom()
+    {
+        $this->datatableQuery->buildQuery();
+        /** @var \Sg\DatatablesBundle\Datatable\View\AbstractDatatableView $datatableView */
+        $datatableView = $this->getPrivateProperty($this->datatableQuery, 'datatableView');
 
-    public function testSetOrderByEmptyRequestParams()
+        $dqlParts = $this->datatableQuery->getQuery()->getDQLParts();
+
+        // Check "FROM"
+        $this->assertNotEmpty($dqlParts['from']);
+
+        /** @var \Doctrine\ORM\Query\Expr\From $fromPart */
+        $fromPart = $dqlParts['from'][0];
+
+        $this->assertNotEmpty($fromPart->getFrom());
+        $this->assertContains($datatableView->getEntity(), $fromPart->getFrom());
+    }
+
+    public function testBuildQueryCheckSelect()
+    {
+        $this->datatableQuery->buildQuery();
+
+        $dqlParts = $this->datatableQuery->getQuery()->getDQLParts();
+
+        // Check "SELECT"
+        $this->assertNotEmpty($dqlParts['select']);
+
+        /** @var \Doctrine\ORM\Query\Expr\Select $selectPart */
+        $selectPart = $dqlParts['select'][0];
+        $selectPartFirst = current($selectPart->getParts());
+
+        $this->assertNotEmpty($selectPart->getParts());
+        $this->assertCount(1, $selectPart->getParts());
+        $this->assertContains('partial', $selectPartFirst);
+        $this->assertContains('id', $selectPartFirst);
+        $this->assertContains('title', $selectPartFirst);
+    }
+
+    public function testBuildQueryCheckWhereWithGlobalSearch()
+    {
+        // Fake a global search
+        $extendedRequestParams = array(
+            'search' => array(
+                'value' => 'test',
+            ),
+        );
+        $this->extendPrivateArrayProperty($this->datatableQuery, 'requestParams', $extendedRequestParams);
+
+        $this->datatableQuery->buildQuery();
+
+        $dqlParts = $this->datatableQuery->getQuery()->getDQLParts();
+
+        // Check "WHERE"
+        $this->assertNotEmpty($dqlParts['where']);
+        $this->assertInstanceOf('\Doctrine\ORM\Query\Expr\Orx', $dqlParts['where']);
+
+        $whereParts = $dqlParts['where']->getParts();
+        $this->assertNotEmpty($whereParts);
+
+        /** @var \Doctrine\ORM\Query\Expr\Comparison $wherePartOne */
+        $wherePartOne = $whereParts[0];
+        $this->assertNotEmpty($wherePartOne);
+        $this->assertContains('id', $wherePartOne->getLeftExpr());
+
+        /** @var \Doctrine\ORM\Query\Expr\Comparison $wherePartTwo */
+        $wherePartTwo = $whereParts[1];
+        $this->assertNotEmpty($wherePartTwo);
+        $this->assertContains('title', $wherePartTwo->getLeftExpr());
+    }
+
+    public function testBuildQueryCheckWhereWithIndividualSearch()
+    {
+        // Fake a global search
+        $extendedRequestParams = array(
+            'search'  => array(
+                'value' => '',
+            ),
+            'columns' => array(
+                // Column "Id"
+                array('search' => array('value' => 'foo')),
+                // Column "Title"
+                array('search' => array('value' => 'bar')),
+            ),
+        );
+        $this->extendPrivateArrayProperty($this->datatableQuery, 'requestParams', $extendedRequestParams);
+        $this->setPrivateProperty($this->datatableQuery, 'individualFiltering', true);
+
+        $this->datatableQuery->buildQuery();
+
+        $dqlParts = $this->datatableQuery->getQuery()->getDQLParts();
+
+        // Check "WHERE"
+        $this->assertNotEmpty($dqlParts['where']);
+        $this->assertInstanceOf('\Doctrine\ORM\Query\Expr\Andx', $dqlParts['where']);
+
+        $whereParts = current($dqlParts['where']->getParts())->getParts();
+        $this->assertNotEmpty($whereParts);
+
+        /** @var \Doctrine\ORM\Query\Expr\Comparison $wherePartOne */
+        $wherePartOne = $whereParts[0];
+        $this->assertNotEmpty($wherePartOne);
+        $this->assertContains('id', $wherePartOne->getLeftExpr());
+
+        /** @var \Doctrine\ORM\Query\Expr\Comparison $wherePartTwo */
+        $wherePartTwo = $whereParts[1];
+        $this->assertNotEmpty($wherePartTwo);
+        $this->assertContains('title', $wherePartTwo->getLeftExpr());
+    }
+
+    public function testBuildQueryCheckWhereWithIndividualSearchWithEmptySearchValue()
+    {
+        // Fake a global search
+        $extendedRequestParams = array(
+            'search'  => array(
+                'value' => '',
+            ),
+            'columns' => array(
+                // Column "Id"
+                array('search' => array('value' => 'foo')),
+                // Column "Title"
+                array('search' => array('value' => '')),
+            ),
+        );
+        $this->extendPrivateArrayProperty($this->datatableQuery, 'requestParams', $extendedRequestParams);
+        $this->setPrivateProperty($this->datatableQuery, 'individualFiltering', true);
+
+        $this->datatableQuery->buildQuery();
+
+        $dqlParts = $this->datatableQuery->getQuery()->getDQLParts();
+
+        // Check "WHERE"
+        $this->assertNotEmpty($dqlParts['where']);
+        $this->assertInstanceOf('\Doctrine\ORM\Query\Expr\Andx', $dqlParts['where']);
+
+        $whereParts = current($dqlParts['where']->getParts())->getParts();
+        $this->assertNotEmpty($whereParts);
+
+        /** @var \Doctrine\ORM\Query\Expr\Comparison $wherePartOne */
+        $wherePartOne = $whereParts[0];
+        $this->assertNotEmpty($wherePartOne);
+        $this->assertContains('id', $wherePartOne->getLeftExpr());
+
+        $this->assertArrayNotHasKey(1, $whereParts);
+    }
+
+    public function testBuildQueryCheckWhereWithIndividualSearchWithNullAsSearchValue()
+    {
+        // Fake a global search
+        $extendedRequestParams = array(
+            'search'  => array(
+                'value' => '',
+            ),
+            'columns' => array(
+                // Column "Id"
+                array('search' => array('value' => 'foo')),
+                // Column "Title"
+                array('search' => array('value' => 'null')),
+            ),
+        );
+        $this->extendPrivateArrayProperty($this->datatableQuery, 'requestParams', $extendedRequestParams);
+        $this->setPrivateProperty($this->datatableQuery, 'individualFiltering', true);
+
+        $this->datatableQuery->buildQuery();
+
+        $dqlParts = $this->datatableQuery->getQuery()->getDQLParts();
+
+        // Check "WHERE"
+        $this->assertNotEmpty($dqlParts['where']);
+        $this->assertInstanceOf('\Doctrine\ORM\Query\Expr\Andx', $dqlParts['where']);
+
+        $whereParts = current($dqlParts['where']->getParts())->getParts();
+        $this->assertNotEmpty($whereParts);
+
+        /** @var \Doctrine\ORM\Query\Expr\Comparison $wherePartOne */
+        $wherePartOne = $whereParts[0];
+        $this->assertNotEmpty($wherePartOne);
+        $this->assertContains('id', $wherePartOne->getLeftExpr());
+
+        $this->assertArrayNotHasKey(1, $whereParts);
+    }
+
+    public function testBuildQueryCheckOrderByWithEmptyRequestParams()
     {
         $this->datatableQuery->buildQuery();
 
@@ -70,7 +258,7 @@ class DatatableQueryTest extends BaseDatatablesTestCase
         $this->assertEmpty($dqlParts['orderBy']);
     }
 
-    public function testSetOrderByWithOrderableColumns()
+    public function testBuildQueryCheckOrderByWithOrderableColumns()
     {
         $extendedRequestParams = array(
             'order' => array(
@@ -94,7 +282,7 @@ class DatatableQueryTest extends BaseDatatablesTestCase
         $this->assertContains('title desc', $orderByPartTwo[0]);
     }
 
-    public function testSetOrderByWithOrderableColumnsContaingNumbersInStrings()
+    public function testBuildQueryCheckOrderByWithOrderableColumnsContaingNumbersInStrings()
     {
         $extendedRequestParams = array(
             'order' => array(
@@ -122,5 +310,50 @@ class DatatableQueryTest extends BaseDatatablesTestCase
 
         $orderByPartTwo = $this->getPrivateProperty($dqlParts['orderBy'][1], 'parts');
         $this->assertContains('title_order_as_int desc', $orderByPartTwo[0]);
+    }
+
+    public function testBuildQueryCheckLimitWithNoLimitGiven()
+    {
+        $this->datatableQuery->buildQuery();
+
+        // Check "LIMIT"
+        $qb = $this->datatableQuery->getQuery();
+
+        $this->assertNull($qb->getFirstResult());
+        $this->assertNull($qb->getMaxResults());
+    }
+
+    public function testBuildQueryCheckLimitWithInvalidLength()
+    {
+        $extendedRequestParams = array(
+            'start'  => 10,
+            'length' => -1,
+        );
+        $this->extendPrivateArrayProperty($this->datatableQuery, 'requestParams', $extendedRequestParams);
+
+        $this->datatableQuery->buildQuery();
+
+        // Check "LIMIT"
+        $qb = $this->datatableQuery->getQuery();
+
+        $this->assertNull($qb->getFirstResult());
+        $this->assertNull($qb->getMaxResults());
+    }
+
+    public function testBuildQueryCheckLimit()
+    {
+        $extendedRequestParams = array(
+            'start'  => 10,
+            'length' => 20,
+        );
+        $this->extendPrivateArrayProperty($this->datatableQuery, 'requestParams', $extendedRequestParams);
+
+        $this->datatableQuery->buildQuery();
+
+        // Check "LIMIT"
+        $qb = $this->datatableQuery->getQuery();
+
+        $this->assertEquals(10, $qb->getFirstResult());
+        $this->assertEquals(20, $qb->getMaxResults());
     }
 }

--- a/Tests/DatatableTest.php
+++ b/Tests/DatatableTest.php
@@ -16,32 +16,49 @@ namespace Sg\DatatablesBundle\Tests;
  *
  * @package Sg\DatatablesBundle\Tests
  */
-class DatatableTest extends \PHPUnit_Framework_TestCase
+class DatatableTest extends BaseDatatablesTestCase
 {
     public function testCreate()
     {
-        $tableClass = 'Sg\DatatablesBundle\Tests\Datatables\PostDatatable';
-
-        $authorizationChecker = $this->getMockBuilder('Symfony\Component\Security\Core\Authorization\AuthorizationCheckerInterface')
-            ->getMock();
-
-        $securityToken = $this->getMockBuilder('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')
-            ->getMock();
-
-        $translator = $this->getMockBuilder('Symfony\Component\Translation\TranslatorInterface')
-            ->getMock();
-
-        $router = $this->getMockBuilder('Symfony\Component\Routing\RouterInterface')
-            ->getMock();
-
-        $em = $this->getMockBuilder('Doctrine\ORM\EntityManagerInterface')
-            ->getMock();
-
-        /** @var \Sg\DatatablesBundle\Tests\Datatables\PostDatatable $table */
-        $table = new $tableClass($authorizationChecker, $securityToken, $translator, $router, $em);
+        $table = $this->createDummyDatatable();
 
         $this->assertEquals('post_datatable', $table->getName());
 
         $table->buildDatatable();
+    }
+
+    public function testCreateDatatableChecksOptions()
+    {
+        $table = $this->createDummyDatatable();
+        $table->buildDatatable();
+
+        $this->assertNotEmpty($table->getTopActions());
+        $this->assertNotEmpty($table->getFeatures());
+        $this->assertNotEmpty($table->getAjax());
+        $this->assertNotEmpty($table->getOptions());
+    }
+
+    public function testCreateDatatableCheckColumns()
+    {
+        $table = $this->createDummyDatatable();
+        $table->buildDatatable();
+
+        /**
+         * @var \Sg\DatatablesBundle\Datatable\Column\AbstractColumn[] $columns
+         */
+        $columns = $table->getColumnBuilder()->getColumns();
+
+        $this->assertNotEmpty($columns);
+        $this->assertCount(2, $columns);
+
+        $columnOneOptions = $this->getPrivateProperty($columns[0], 'options');
+
+        $this->assertEquals('id', $columns[0]->getData());
+        $this->assertEquals('Id', $columnOneOptions['title']);
+
+        $columnTwoOptions = $this->getPrivateProperty($columns[1], 'options');
+
+        $this->assertEquals('title', $columns[1]->getData());
+        $this->assertEquals('Title', $columnTwoOptions['title']);
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "require-dev": {
         "sensio/generator-bundle": "~2.5|~3.0",
         "doctrine/orm": "^2.2.3",
-        "phpunit/phpunit": "^5.6",
+        "phpunit/phpunit": "4.8.0",
         "twig/twig": "^1.26"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
     },
     "require-dev": {
         "sensio/generator-bundle": "~2.5|~3.0",
-        "doctrine/orm": "^2.2.3",
-        "phpunit/phpunit": "4.8.0",
+        "doctrine/orm": "^2.4.0",
+        "phpunit/phpunit": "~4.8|~5.2",
         "twig/twig": "^1.26"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,9 @@
     },
     "require-dev": {
         "sensio/generator-bundle": "~2.5|~3.0",
-        "doctrine/orm": "^2.2.3"
+        "doctrine/orm": "^2.2.3",
+        "phpunit/phpunit": "^5.6",
+        "twig/twig": "^1.26"
     },
     "suggest": {
         "components/jquery": "~1.12",


### PR DESCRIPTION
This PR solves the issue https://github.com/stwe/DatatablesBundle/issues/441. It casts columns with the type "num", "int" or "integer" to numbers to properly sort them in the database.

I also provided some more unit tests testing the class `DatatableQuery` as much as possible.