### PR TITLE
Add support for all numeric field types to editable

### DIFF
--- a/Controller/EditableController.php
+++ b/Controller/EditableController.php
@@ -76,7 +76,7 @@ class EditableController extends Controller
                     $value = new \DateTime($value);
                     break;
                 case 'boolean':
-                    $value = (bool) $value;
+                    $value = $this->strToBool($value);
                     break;
                 case 'string':
                     break;

--- a/Controller/EditableController.php
+++ b/Controller/EditableController.php
@@ -17,6 +17,7 @@ use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
  * Class EditableController
@@ -44,11 +45,9 @@ class EditableController extends Controller
             $id = $request->request->get('pk');
             $value = $request->request->get('value');
             $token = $request->request->get('token');
+            $accessor = PropertyAccess::createPropertyAccessor();
 
-            $supportedFieldType = false;
             $fieldType = null;
-            $getter = null;
-            $setter = null;
 
             if (!$this->isCsrfTokenValid('editable', $token)) {
                 throw new AccessDeniedException('The CSRF token is invalid.');
@@ -58,48 +57,46 @@ class EditableController extends Controller
             $metadata = $em->getClassMetadata($entityName);
 
             if (false === strstr($field, '.')) {
-                $setter = 'set' . ucfirst($field);
                 $fieldType = $metadata->getTypeOfField($field);
             } else {
                 $parts = explode('.', $field);
-                $getter = 'get' . ucfirst($parts[0]);
-                $setter = 'set' . ucfirst($parts[1]);
                 $targetClass = $metadata->getAssociationTargetClass($parts[0]);
                 $targetMeta = $em->getClassMetadata($targetClass);
                 $fieldType = $targetMeta->getTypeOfField($parts[1]);
             }
 
             $entity = $em->getRepository($entityName)->find($id);
+
             if (!$entity) {
                 throw $this->createNotFoundException('The entity does not exist.');
             }
 
             switch ($fieldType) {
                 case 'datetime':
-                    $dateTime = new \DateTime($value);
-                    null === $getter ? $entity->$setter($dateTime) : $entity->$getter()->$setter($dateTime);
-                    $supportedFieldType = true;
+                    $value = new \DateTime($value);
                     break;
                 case 'boolean':
-                    null === $getter ? $entity->$setter($this->strToBool($value)) : $entity->$getter()->$setter($this->strToBool($value));
-                    $supportedFieldType = true;
+                    $value = (bool) $value;
                     break;
                 case 'string':
-                    null === $getter ? $entity->$setter($value) : $entity->$getter()->$setter($value);
-                    $supportedFieldType = true;
                     break;
+                case 'smallint':
                 case 'integer':
-                    null === $getter ? $entity->$setter((int) $value) : $entity->$getter()->$setter((int) $value);
-                    $supportedFieldType = true;
+                case 'bigint':
+                    $value = (int) $value;
+                    break;
+                case 'float':
+                case 'decimal':
+                    $value = (float) $value;
                     break;
                 default:
                     throw new \Exception("editAction(): The field type {$fieldType} is not supported.");
             }
 
-            if (true === $supportedFieldType) {
-                $em->persist($entity);
-                $em->flush();
-            }
+            $accessor->setValue($entity, $field, $value);
+
+            $em->persist($entity);
+            $em->flush();
 
             return new Response('Success', 200);
         }

--- a/Resources/views/Datatable/editable.html.twig
+++ b/Resources/views/Datatable/editable.html.twig
@@ -32,6 +32,7 @@
                 return params;
             },
             container: 'body',
+            emptytext: "{{ 'datatables.actions.edit'|trans({}, 'messages') }}",
             {# many-to-one associations, Pipelining and the Responsive-extension need a complete table redraw #}
             {% if view_ajax.pipeline > 0 or column.isAssociation or view_features.extensions.responsive is defined and true == view_features.extensions.responsive %}
             success: function(response, newValue) {

--- a/Resources/views/Datatable/render_functions.js.twig
+++ b/Resources/views/Datatable/render_functions.js.twig
@@ -86,16 +86,13 @@ function render_editable_text(data, type, row, meta, colData, colIndex) {
         return data;
     }
 
-    if (data != null) {
-        var str = colData.split(".").join("_");
-        var spanClass = "sg-editable-" + str;
-        var result = '<span class="' + spanClass + '"';
-        result += 'data-pk="' + row.id + '"data-type="text"' + '>' + data + '</span>';
+    var editText = null == data ? '' : data;
+    var str = colData.split(".").join("_");
+    var spanClass = "sg-editable-" + str;
+    var result = '<span class="' + spanClass + '"';
+    result += 'data-pk="' + row.id + '"data-type="text"' + '>' + editText + '</span>';
 
-        return result;
-    } else {
-        return null;
-    }
+    return result;
 }
 
 function render_editable_datetime(data, type, row, meta, colData, dateFormat, colIndex) {


### PR DESCRIPTION
This PR implements the following field types in editable:
1. smallint
2. bigint
3. integer
4. decimal
5. float

I refactored the controller method to leverage Symfony's PropertyAccessor.
