### PR TITLE
Use the entity class name instead of the database table name

### DIFF
--- a/Response/DatatableQueryBuilder.php
+++ b/Response/DatatableQueryBuilder.php
@@ -633,7 +633,7 @@ class DatatableQueryBuilder
      */
     private function getTableName(ClassMetadata $metadata)
     {
-        return strtolower($metadata->getTableName());
+        return strtolower($metadata->getReflectionClass()->getShortName());
     }
 
     /**

--- a/Tests/DatatableTest.php
+++ b/Tests/DatatableTest.php
@@ -60,12 +60,12 @@ class DatatableTest extends \PHPUnit_Framework_TestCase
     {
         $mock = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadata')
             ->disableOriginalConstructor()
-            ->setMethods(array('getTableName'))
+            ->setMethods(array('getEntityShortName'))
             ->getMock();
 
         $mock->expects($this->any())
-            ->method('getTableName')
-            ->will($this->returnValue('{tableName}'));
+            ->method('getEntityShortName')
+            ->will($this->returnValue('{entityShortName}'));
 
         return $mock;
     }


### PR DESCRIPTION
Using the database table name result in weird alias name for the base entity if table name is different from entity name (when using prefix).
This is not very intuitive when we want to manually modify the queryBuilder, because, the base entity will use the table name, and joins ar using entities names.

Example:
```php
/**
 * @ORM\Table(name="Prefix_Entity")
 * @ORM\Entity
 */
class Entity {
    private $id;
    private $name;
    private $joinColumn;
}
/**
 * @ORM\Table(name="Prefix_Join")
 * @ORM\Entity
 */
class Join {
    private $id;
    private $name;
}

// Before
// SELECT partial prefix_entity.{id,name}, partial join.{id,name} 
// FROM Entity prefix_entity LEFT JOIN prefix_entity.join join

// After
// SELECT partial entity.{id,name}, partial join.{id,name} 
// FROM Entity entity LEFT JOIN entity.join join
```