### PR TITLE
Fix integers order by

### DIFF
--- a/Response/DatatableQueryBuilder.php
+++ b/Response/DatatableQueryBuilder.php
@@ -422,44 +422,10 @@ class DatatableQueryBuilder
                 if ('true' == $requestColumn['orderable']) {
                     $columnName = $this->orderColumns[$columnIdx];
                     $orderDirection = $this->requestParams['order'][$i]['dir'];
-                    $columnType = $this->accessor->getValue($this->columns[$columnIdx], 'typeOfField');
 
-                    $this->createOrderBy($columnName, $orderDirection, $columnType);
+                    $this->qb->addOrderBy($columnName, $orderDirection);
                 }
             }
-        }
-
-        return $this;
-    }
-
-    /**
-     * Create order by statements.
-     * In some case we want to order string/varchar database fields as numbers.
-     *
-     * @see http://stackoverflow.com/questions/22993336/how-to-order-varchar-as-int-in-symfony2-doctrine2#23071353
-     *
-     * @param string $columnName
-     * @param string $orderDirection
-     * @param string $columnType
-     *
-     * @return $this
-     */
-    private function createOrderBy($columnName, $orderDirection, $columnType)
-    {
-        switch ($columnType) {
-            case 'integer':
-                $tempOrderColumnName = str_replace('.', '_', $columnName) . '_order_as_int';
-                $this->qb
-                    ->addSelect(sprintf(
-                        'ABS(%s) AS HIDDEN %s',
-                        $columnName,
-                        $tempOrderColumnName
-                    ))
-                    ->addOrderBy($tempOrderColumnName, $orderDirection);
-                break;
-            default:
-                $this->qb->addOrderBy($columnName, $orderDirection);
-                break;
         }
 
         return $this;


### PR DESCRIPTION
Negative number are not properly ordered.

ABS function return the absolute value, so negative numbers become positive which result in an incoherent sorting.

Before:
`0, 1, -2, 4, -5, 8`

After:
`-5, -2, 0, 1, 4, 8`

The only way to order string/varchar database fields as numbers is to cast them.
Doctrine do not provide cast function, so the user have to implement it if needed, and use it with a custom DQL => https://github.com/stwe/DatatablesBundle/pull/551