### PR TITLE
Fix type_of_field allowed values

### DIFF
--- a/Datatable/Column/AbstractColumn.php
+++ b/Datatable/Column/AbstractColumn.php
@@ -320,7 +320,7 @@ abstract class AbstractColumn implements ColumnInterface
 
         $resolver->setAllowedValues('cell_type', array(null, 'th', 'td'));
         $resolver->setAllowedValues('join_type', array(null, 'join', 'leftJoin', 'innerJoin'));
-        $resolver->setAllowedValues('type_of_field', array(null, DoctrineType::getTypesMap()));
+        $resolver->setAllowedValues('type_of_field', array_merge(array(null), array_keys(DoctrineType::getTypesMap())));
 
         return $this;
     }


### PR DESCRIPTION
```php
'type_of_field' => 'integer'
```
throw an exception:
> The option "type_of_field" with value "integer" is invalid. Accepted values are: null, array.