### PR TITLE
Made Paginator parameter fetchJoinCollection settable

### DIFF
--- a/Response/DatatableResponse.php
+++ b/Response/DatatableResponse.php
@@ -122,7 +122,7 @@ class DatatableResponse
      * @return JsonResponse
      * @throws Exception
      */
-    public function getResponse($countAllResults = true, $outputWalkers = false)
+    public function getResponse($countAllResults = true, $outputWalkers = false, $fetchJoinCollection = true)
     {
         if (null === $this->datatable) {
             throw new Exception('DatatableResponse::getResponse(): Set a Datatable class with setDatatable().');
@@ -132,7 +132,7 @@ class DatatableResponse
             throw new Exception('DatatableResponse::getResponse(): A DatatableQueryBuilder instance is needed. Call getDatatableQueryBuilder().');
         }
 
-        $paginator = new Paginator($this->datatableQueryBuilder->execute(), true);
+        $paginator = new Paginator($this->datatableQueryBuilder->execute(), $fetchJoinCollection);
         $paginator->setUseOutputWalkers($outputWalkers);
 
         $formatter = new DatatableFormatter();


### PR DESCRIPTION
Datatable not using join toMany can perform three queries instead of four by setting value to false. See http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/pagination.html