### PR TITLE
fix(javascript): Fix requirement for jQuery to be in header

### DIFF
--- a/Resources/views/datatable/datatable_js.html.twig
+++ b/Resources/views/datatable/datatable_js.html.twig
@@ -8,7 +8,7 @@
  #}
 <script type="text/javascript">
 
-    $(document).ready(function () {
+    document.onreadystatechange = function () {
 
         var selector = "#sg-datatables-{{ sg_datatables_view.name }}";
         var oTable;
@@ -84,6 +84,6 @@
         {% if sg_datatables_view.columnBuilder.uniqueColumn('multiselect') is not null %}
             {{ sg_datatables_render_multiselect_actions( sg_datatables_view.columnBuilder.uniqueColumn('multiselect'), sg_datatables_view.ajax.pipeline) }}
         {% endif %}
-    });
+    };
 
 </script>


### PR DESCRIPTION
* Fix issue which has been caused by jQuery loaded by end of the page. This means if you have jQuery <script> tag just before the end of </body> tag. The datatable would not render and you will get an undefined function error in javascript console and you would need to insert jQuery <script> in the <head> tag.

Closes #609