### PR TITLE
0.13.1 - Fix jQuery not loaded in latest stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,19 @@
 
 [![Latest Stable Version](https://poser.pugx.org/sg/datatablesbundle/v/stable)](https://packagist.org/packages/sg/datatablesbundle) [![Total Downloads](https://poser.pugx.org/sg/datatablesbundle/downloads)](https://packagist.org/packages/sg/datatablesbundle) [![Latest Unstable Version](https://poser.pugx.org/sg/datatablesbundle/v/unstable)](https://packagist.org/packages/sg/datatablesbundle) [![License](https://poser.pugx.org/sg/datatablesbundle/license)](https://packagist.org/packages/sg/datatablesbundle)
 
-## Recent Changes
+## About
 
-Nothing since v0.12.
+This Bundle has reached 50k downloads. "Thank you!" to all the [contributors](https://github.com/stwe/DatatablesBundle/graphs/contributors), users and bug reporters for making this possible!
+
+## Versioning
+
+### 0.x (stable)
+
+Last version is 0.13.
+
+### 1.x (dev)
+
+1.0 is under heavy development. The bundle is completely revised.
 
 ## Screenshots
 

--- a/Resources/doc/columns.md
+++ b/Resources/doc/columns.md
@@ -26,20 +26,20 @@ SgDatatablesBundle:Column:column.html.twig
 | Option          | Type           | Default                | Required | Description |
 |-----------------|----------------|------------------------|----------|-------------|
 | class           | string         | ''                     |          | Class to assign to each cell in the column. |
-| default_content | null or string | null                   |          | Display this default content if value is empty. |
+| default_content | null or string | null                   |          | Default content for a field that can have a null or undefined value. |
 | padding         | string         | ''                     |          | Add padding to the text content used when calculating the optimal width for a table. |
 | name            | string         | ''                     |          | Set a descriptive name for a column. |
 | orderable       | boolean        | true                   |          | Enable or disable ordering on this column. |
-| render          | null or string | null                   |          | **TODO**: is this still used? I can't find any references. |
+| render          | null or string | null                   |          | This property will modify the data that is used by DataTables. |
 | searchable      | boolean        | true                   |          | Enable or disable filtering on the data in this column. |
 | title           | string         | ''                     |          | The displayed column title. This value is not translated automatically. |
 | type            | string         | ''                     |          | Set the column type - used for filtering and sorting string processing. |
 | visible         | boolean        | true                   |          | Display or hide this column completly so no data will be displayed in the browser. |
 | width           | string         | ''                     |          | Adjust the column's width. This value will set the element attribute `style="width: XXXpx;`. |
-| order_sequence  | null or array  | null                   |          | **TODO**: is this value still used? |
+| order_sequence  | null or array  | null                   |          | Control the default ordering direction. |
 | filter          | array          | array('text', array()) |          | See [Filtering](https://github.com/stwe/DatatablesBundle/blob/master/Resources/doc/filter.md#2-serverside-individual-column-filtering) for more information. |
 | add_if          | Closure        | null                   |          | Add a closure to check e.g. the current user's permissions and display a column depending on that result. |
-| default         | string         | ''                     |          | Default content. **TODO**: what is the difference to `default_content`? |
+| default         | string         | ''                     |          | Default content for a field that can have an empty string. |
 | editable        | boolean        | false                  |          | Enable edit mode for this column. |
 | editable_if     | Closure        | null                   |          | Enable edit mode for this column depending on a closure condition e.g. permissions. |
 
@@ -96,20 +96,20 @@ SgDatatablesBundle:Column:array.html.twig
 | Option               | Type           | Default                | Required | Description |
 |----------------------|----------------|------------------------|----------|-------------|
 | class                | string         | ''                     |          | Class to assign to each cell in the column. |
-| default_content      | null or string | null                   |          | Display this default content if value is empty. |
+| default_content      | null or string | null                   |          | Default content for a field that can have a null or undefined value. |
 | padding              | string         | ''                     |          | Add padding to the text content used when calculating the optimal width for a table. |
 | name                 | string         | ''                     |          | Set a descriptive name for a column. |
 | orderable            | boolean        | true                   |          | Enable or disable ordering on this column. |
-| render               | null or string | null                   |          | **TODO**: is this still used? |
+| render               | null or string | null                   |          | This property will modify the data that is used by DataTables. |
 | searchable           | boolean        | true                   |          | Enable or disable filtering on the data in this column. |
 | title                | string         | ''                     |          | The displayed column title. This value is not translated automatically. |
 | type                 | string         | ''                     |          | Set the column type - used for filtering and sorting string processing. |
 | visible              | boolean        | true                   |          | Display or hide this column completly so no data will be displayed in the browser. |
 | width                | string         | ''                     |          | Adjust the column's width. This value will set the element attribute `style="width: XXXpx;`. |
-| order_sequence       | null or array  | null                   |          | **TODO**: is this value still used? |
+| order_sequence       | null or array  | null                   |          | Control the default ordering direction. |
 | filter               | array          | array('text', array()) |          | See [Filtering](https://github.com/stwe/DatatablesBundle/blob/master/Resources/doc/filter.md#2-serverside-individual-column-filtering) for more information. |
 | add_if               | Closure        | null                   |          | Add a closure to check e.g. the current user's permissions and display a column depending on that result. |
-| default              | string         | ''                     |          | Default content. **TODO**: what is the difference to `default_content`? |
+| default              | string         | ''                     |          | Default content for a field that can have an empty string. |
 | data                 | string         |                        | ✔        | Fetch array data from this entity attribute. You can define sub elements e.g. "foo.bar".|
 | count                | boolean        | false                  |          | Count array elements. |
 | count_action         | array          | array()                |          | The counter represents a link, see [Count Action options](#count-action-options). |
@@ -173,20 +173,20 @@ SgDatatablesBundle:Column:column.html.twig
 | Option          | Type           | Default                | Required | Description |
 |-----------------|----------------|------------------------|----------|-------------|
 | class           | string         | ''                     |          | Class to assign to each cell in the column. |
-| default_content | null or string | null                   |          | Display this default content if value is empty. |
+| default_content | null or string | null                   |          | Default content for a field that can have a null or undefined value. |
 | padding         | string         | ''                     |          | Add padding to the text content used when calculating the optimal width for a table. |
 | name            | string         | ''                     |          | Set a descriptive name for a column. |
 | orderable       | boolean        | false                  |          | Enable or disable ordering on this column. |
-| render          | null or string | null                   |          | **TODO**: is this still used? I can't find any references. |
+| render          | null or string | null                   |          | This property will modify the data that is used by DataTables. |
 | searchable      | boolean        | false                  |          | Enable or disable filtering on the data in this column. |
 | title           | string         | ''                     |          | The displayed column title. This value is not translated automatically. |
 | type            | string         | ''                     |          | Set the column type - used for filtering and sorting string processing. |
 | visible         | boolean        | true                   |          | Display or hide this column completly so no data will be displayed in the browser. |
 | width           | string         | ''                     |          | Adjust the column's width. This value will set the element attribute `style="width: XXXpx;`. |
-| order_sequence  | null or array  | null                   |          | **TODO**: is this value still used? |
+| order_sequence  | null or array  | null                   |          | Control the default ordering direction. |
 | filter          | array          | array('text', array()) |          | See [Filtering](https://github.com/stwe/DatatablesBundle/blob/master/Resources/doc/filter.md#2-serverside-individual-column-filtering) for more information. |
 | add_if          | Closure        | null                   |          | Add a closure to check e.g. the current user's permissions and display a column depending on that result. |
-| default         | string         | ''                     |          | Default content. **TODO**: what is the difference to `default_content`? |
+| default         | string         | ''                     |          | Default content for a field that can have an empty string. |
 
 ### Example
 
@@ -212,17 +212,17 @@ SgDatatablesBundle:Column:boolean.html.twig
 | Option          | Type           | Default                | Required | Description |
 |-----------------|----------------|------------------------|----------|-------------|
 | class           | string         | ''                     |          | Class to assign to each cell in the column. |
-| default_content | null or string | null                   |          | Display this default content if value is empty. |
+| default_content | null or string | null                   |          | Default content for a field that can have a null or undefined value. |
 | padding         | string         | ''                     |          | Add padding to the text content used when calculating the optimal width for a table. |
 | name            | string         | ''                     |          | Set a descriptive name for a column. |
 | orderable       | boolean        | true                   |          | Enable or disable ordering on this column. |
-| render          | null or string | 'render_boolean'       |          | **TODO**: is this still used? I can't find any references. |
+| render          | null or string | 'render_boolean'       |          | This property will modify the data that is used by DataTables. |
 | searchable      | boolean        | true                   |          | Enable or disable filtering on the data in this column. |
 | title           | string         | ''                     |          | The displayed column title. This value is not translated automatically. |
 | type            | string         | ''                     |          | Set the column type - used for filtering and sorting string processing. |
 | visible         | boolean        | true                   |          | Display or hide this column completly so no data will be displayed in the browser. |
 | width           | string         | ''                     |          | Adjust the column's width. This value will set the element attribute `style="width: XXXpx;`. |
-| order_sequence  | null or array  | null                   |          | **TODO**: is this value still used? |
+| order_sequence  | null or array  | null                   |          | Control the default ordering direction. |
 | true_icon       | string         | ''                     |          | Display a icon if the boolean condition is true e.g. `glyphicon glyphicon-ok`. |
 | false_icon      | string         | ''                     |          | Display a icon if the boolean condition is false e.g. `glyphicon glyphicon-remove`. |
 | true_label      | string         | ''                     |          | Display text if the boolean condition is true e.g. `yes`. |
@@ -264,17 +264,17 @@ SgDatatablesBundle:Column:datetime.html.twig
 | Option          | Type           | Default                | Required | Description |
 |-----------------|----------------|------------------------|----------|-------------|
 | class           | string         | ''                     |          | Class to assign to each cell in the column. |
-| default_content | null or string | null                   |          | Display this default content if value is empty. |
+| default_content | null or string | null                   |          | Default content for a field that can have a null or undefined value. |
 | padding         | string         | ''                     |          | Add padding to the text content used when calculating the optimal width for a table. |
 | name            | string         | ''                     |          | Set a descriptive name for a column. |
 | orderable       | boolean        | true                   |          | Enable or disable ordering on this column. |
-| render          | null or string | 'render_datetime'      |          | **TODO**: is this still used? I can't find any references. |
+| render          | null or string | 'render_datetime'      |          | This property will modify the data that is used by DataTables. |
 | searchable      | boolean        | true                   |          | Enable or disable filtering on the data in this column. |
 | title           | string         | ''                     |          | The displayed column title. This value is not translated automatically. |
 | type            | string         | ''                     |          | Set the column type - used for filtering and sorting string processing. |
 | visible         | boolean        | true                   |          | Display or hide this column completly so no data will be displayed in the browser. |
 | width           | string         | ''                     |          | Adjust the column's width. This value will set the element attribute `style="width: XXXpx;`. |
-| order_sequence  | null or array  | null                   |          | **TODO**: is this value still used? |
+| order_sequence  | null or array  | null                   |          | Control the default ordering direction. |
 | filter          | array          | array('text', array()) |          | See [Filtering](https://github.com/stwe/DatatablesBundle/blob/master/Resources/doc/filter.md#2-serverside-individual-column-filtering) for more information. |
 | add_if          | Closure        | null                   |          | Add a closure to check e.g. the current user's permissions and display a column depending on that result. |
 | date_format     | string         | 'lll'                  |          | Format date, see [Date Parameteres](http://php.net/manual/de/function.date.php#refsect1-function.date-parameters). |
@@ -307,17 +307,17 @@ SgDatatablesBundle:Column:timeago.html.twig
 | Option          | Type           | Default                | Required | Description |
 |-----------------|----------------|------------------------|----------|-------------|
 | class           | string         | ''                     |          | Class to assign to each cell in the column. |
-| default_content | null or string | null                   |          | Display this default content if value is empty. |
+| default_content | null or string | null                   |          | Default content for a field that can have a null or undefined value. |
 | padding         | string         | ''                     |          | Add padding to the text content used when calculating the optimal width for a table. |
 | name            | string         | ''                     |          | Set a descriptive name for a column. |
 | orderable       | boolean        | true                   |          | Enable or disable ordering on this column. |
-| render          | null or string | 'render_timeago'       |          | **TODO**: is this still used? I can't find any references. |
+| render          | null or string | 'render_timeago'       |          | This property will modify the data that is used by DataTables. |
 | searchable      | boolean        | true                   |          | Enable or disable filtering on the data in this column. |
 | title           | string         | ''                     |          | The displayed column title. This value is not translated automatically. |
 | type            | string         | ''                     |          | Set the column type - used for filtering and sorting string processing. |
 | visible         | boolean        | true                   |          | Display or hide this column completly so no data will be displayed in the browser. |
 | width           | string         | ''                     |          | Adjust the column's width. This value will set the element attribute `style="width: XXXpx;`. |
-| order_sequence  | null or array  | null                   |          | **TODO**: is this value still used? |
+| order_sequence  | null or array  | null                   |          | Control the default ordering direction. |
 | filter          | array          | array('text', array()) |          | See [Filtering](https://github.com/stwe/DatatablesBundle/blob/master/Resources/doc/filter.md#2-serverside-individual-column-filtering) for more information. |
 | add_if          | Closure        | null                   |          | Add a closure to check e.g. the current user's permissions and display a column depending on that result. |
 
@@ -603,7 +603,7 @@ SgDatatablesBundle:Column:image.html.twig
 | type                     | string         | ''                     |          | Set the column type - used for filtering and sorting string processing. |
 | visible                  | boolean        | true                   |          | Display or hide this column completly so no data will be displayed in the browser. |
 | width                    | string         | ''                     |          | Adjust the column's width. This value will set the element attribute `style="width: XXXpx;`. |
-| order_sequence           | null or array  | null                   |          | **TODO**: is this value still used? |
+| order_sequence           | null or array  | null                   |          | Control the default ordering direction. |
 | filter                   | array          | array('text', array()) |          | See [Filtering](https://github.com/stwe/DatatablesBundle/blob/master/Resources/doc/filter.md#2-serverside-individual-column-filtering) for more information. |
 | add_if                   | Closure        | null                   |          | Add a closure to check e.g. the current user's permissions and display a column depending on that result. |
 | imagine_filter           | string         | ''                     |          | The imagine filter used to display image preview, see (LiipImagineBundle)[https://github.com/liip/LiipImagineBundle#basic-usage]. |
@@ -728,7 +728,7 @@ SgDatatablesBundle:Column:image.html.twig
 | type                    | string         | ''                     |          | Set the column type - used for filtering and sorting string processing. |
 | visible                 | boolean        | true                   |          | Display or hide this column completly so no data will be displayed in the browser. |
 | width                   | string         | ''                     |          | Adjust the column's width. This value will set the element attribute `style="width: XXXpx;`. |
-| order_sequence          | null or array  | null                   |          | **TODO**: is this value still used? |
+| order_sequence          | null or array  | null                   |          | Control the default ordering direction. |
 | filter                  | array          | array('text', array()) |          | See [Filtering](https://github.com/stwe/DatatablesBundle/blob/master/Resources/doc/filter.md#2-serverside-individual-column-filtering) for more information. |
 | add_if                  | Closure        | null                   |          | Add a closure to check e.g. the current user's permissions and display a column depending on that result. |
 | imagine_filter          | string         |                        | ✔        | The imagine filter used to display image preview, see (LiipImagineBundle)[https://github.com/liip/LiipImagineBundle#basic-usage]. |
@@ -773,13 +773,13 @@ SgDatatablesBundle:Column:progress_bar.html.twig
 | padding              | string         | ''                    |          | Add padding to the text content used when calculating the optimal width for a table. |
 | name                 | string         | ''                    |          | Set a descriptive name for a column. |
 | orderable            | boolean        | true                  |          | Enable or disable ordering on this column. |
-| render               | null or string | render_progress_bar   |          | **TODO**: is this still used? I can't find any references. |
+| render               | null or string | render_progress_bar   |          | This property will modify the data that is used by DataTables. |
 | searchable           | boolean        | true                  |          | Enable or disable filtering on the data in this column. |
 | title                | string         | ''                    |          | The displayed column title. This value is not translated automatically. |
 | type                 | string         | ''                    |          | Set the column type - used for filtering and sorting string processing. |
 | visible              | boolean        | true                  |          | Display or hide this column completly so no data will be displayed in the browser. |
 | width                | string         | ''                    |          | Adjust the column's width. This value will set the element attribute `style="width: XXXpx;`. |
-| order_sequence       | null or array  | null                  |          | **TODO**: is this value still used? |
+| order_sequence       | null or array  | null                  |          | Control the default ordering direction. |
 | filter               | array          | see the below example |          | See [Filtering](https://github.com/stwe/DatatablesBundle/blob/master/Resources/doc/filter.md#2-serverside-individual-column-filtering) for more information. |
 | add_if               | Closure        | null                  |          | Add a closure to check e.g. the current user's permissions and display a column depending on that result. |
 | bar_classes          | string         | ''                    |          | |

--- a/Resources/doc/setup.md
+++ b/Resources/doc/setup.md
@@ -85,16 +85,16 @@
 
 ### Action options
 
-| Option           | Type        | Default                      |          |
-|------------------|-------------|------------------------------|----------|
-| route            | string      |                              | required |
-| route_parameters | array       | array()                      |          |
-| icon             | string      | ''                           |          |
-| label            | string      | ''                           |          |
-| confirm          | boolean     | false                        |          |
-| confirm_message  | string      | 'datatables.bulk.confirmMsg' |          |
-| attributes       | array       | array()                      |          |
-| render_if        | Closure     | null                         |          |
+| Option           | Type        | Default                      |                       |
+|------------------|-------------|------------------------------|-----------------------|
+| route            | string      |                              | required              |
+| route_parameters | array       | array()                      | Is currently not used |
+| icon             | string      | ''                           |                       |
+| label            | string      | ''                           |                       |
+| confirm          | boolean     | false                        |                       |
+| confirm_message  | string      | 'datatables.bulk.confirmMsg' |                       |
+| attributes       | array       | array()                      |                       |
+| render_if        | Closure     | null                         |                       |
 
 ## 3. Callbacks
 

--- a/Resources/views/Datatable/editable.html.twig
+++ b/Resources/views/Datatable/editable.html.twig
@@ -32,6 +32,7 @@
                 return params;
             },
             container: 'body',
+            emptytext: "{{ 'datatables.actions.edit'|trans({}, 'messages') }}",
             {# many-to-one associations, Pipelining and the Responsive-extension need a complete table redraw #}
             {% if view_ajax.pipeline > 0 or column.isAssociation or view_features.extensions.responsive is defined and true == view_features.extensions.responsive %}
             success: function(response, newValue) {

--- a/Resources/views/Datatable/render_functions.js.twig
+++ b/Resources/views/Datatable/render_functions.js.twig
@@ -86,16 +86,13 @@ function render_editable_text(data, type, row, meta, colData, colIndex) {
         return data;
     }
 
-    if (data != null) {
-        var str = colData.split(".").join("_");
-        var spanClass = "sg-editable-" + str;
-        var result = '<span class="' + spanClass + '"';
-        result += 'data-pk="' + row.id + '"data-type="text"' + '>' + data + '</span>';
+    var editText = null == data ? '' : data;
+    var str = colData.split(".").join("_");
+    var spanClass = "sg-editable-" + str;
+    var result = '<span class="' + spanClass + '"';
+    result += 'data-pk="' + row.id + '"data-type="text"' + '>' + editText + '</span>';
 
-        return result;
-    } else {
-        return null;
-    }
+    return result;
 }
 
 function render_editable_datetime(data, type, row, meta, colData, dateFormat, colIndex) {


### PR DESCRIPTION
@stwe You don't have branch for the v0.13 release and I can not make Pull Request for the tag. Just push a branch for the 0.13 and switch the base. This pull request solves an issue #609 with 0.13 version. And should be distributed as fix with 0.13.1 version number.