### PR TITLE
multiselectaction with multiple datatables on the same page

### DIFF
--- a/Datatable/Action/MultiselectAction.php
+++ b/Datatable/Action/MultiselectAction.php
@@ -34,7 +34,7 @@ class MultiselectAction extends Action
      */
     public function setAttributes($attributes)
     {
-        $value = 'sg-datatables-'.$this->datatableName.'-multiselect-action';
+        $value = 'sg-datatables-multiselect-action sg-datatables-'.$this->datatableName.'-multiselect-action';
 
         if (is_array($attributes)) {
             if (array_key_exists('href', $attributes)) {

--- a/Resources/views/datatable/datatable_js.html.twig
+++ b/Resources/views/datatable/datatable_js.html.twig
@@ -82,7 +82,7 @@
         createDatatable();
 
         {% if sg_datatables_view.columnBuilder.uniqueColumn('multiselect') is not null %}
-            {{ sg_datatables_render_multiselect_actions( sg_datatables_view.columnBuilder.uniqueColumn('multiselect'), sg_datatables_view.ajax.pipeline) }}
+            {{ sg_datatables_render_multiselect_actions( sg_datatables_view.columnBuilder.uniqueColumn('multiselect'), sg_datatables_view.ajax.pipeline, sg_datatables_view.name) }}
         {% endif %}
     });
 

--- a/Resources/views/datatable/multiselect_actions.html.twig
+++ b/Resources/views/datatable/multiselect_actions.html.twig
@@ -140,7 +140,7 @@ $("#sg-datatables-{{ datatable_name }}").on("click", "input.sg-datatables-{{ dat
 });
 
 {# handle multiselect action click #}
-$(".sg-datatables-{{ datatable_name }}-multiselect-action").on("click", function(event) {
+$("#sg-datatables-{{ datatable_name }}-multiselect-actions .sg-datatables-multiselect-action").on("click", function(event) {
     event.preventDefault();
 
     if (oTable.rows(".selected").data().length > 0) {

--- a/Twig/DatatableTwigExtension.php
+++ b/Twig/DatatableTwigExtension.php
@@ -205,16 +205,17 @@ class DatatableTwigExtension extends Twig_Extension
      * @param Twig_Environment $twig
      * @param ColumnInterface  $multiselectColumn
      * @param int              $pipeline
+     * @param string           $datatableName
      *
      * @return string
      */
-    public function datatablesRenderMultiselectActions(Twig_Environment $twig, ColumnInterface $multiselectColumn, $pipeline)
+    public function datatablesRenderMultiselectActions(Twig_Environment $twig, ColumnInterface $multiselectColumn, $pipeline, $datatableName = '')
     {
         $parameters = array();
         $values = array();
         $actions = $this->accessor->getValue($multiselectColumn, 'actions');
         $domId = $this->accessor->getValue($multiselectColumn, 'renderActionsToId');
-        $datatableName = $this->accessor->getValue($multiselectColumn, 'datatableName');
+        $datatableName = $datatableName ?: $this->accessor->getValue($multiselectColumn, 'datatableName');
 
         /** @var Action $action */
         foreach ($actions as $actionKey => $action) {


### PR DESCRIPTION
First of all thakns for Your Great job, it's awesome bundle.
I had a problem with multiple datatables generated for each category, i needed display them on one page.

In my case there is one original databele and multiple tabs with dynamic datatbles created from original datable. I pass an extra paramater in bulidDatatable method to suffix datatablename.

The code below explain how it works.
The code abowe is the hotfix resolve the problem.
The question is, how do it better :)

`// in controler`
`$datatable->buildDatatable(['category_slug' => $query_cslug]);`

`// in datatable`
`$this->dtName = 'media_datatable_' . $options['category_slug'];`

```php
/**
 * {@inheritdoc}
 */
public function getName()
{
   return $this->dtName;
}
```