### PR TITLE
responsive && invidual filtering fix

### DIFF
--- a/Resources/views/datatable/datatable_html.html.twig
+++ b/Resources/views/datatable/datatable_html.html.twig
@@ -14,7 +14,7 @@
     {% endif %}
 {% endif %}
 
-<table id="sg-datatables-{{ sg_datatables_view.name }}" class="{{ sg_datatables_view.options.classes }}" cellspacing="0" width="100%">
+<table id="sg-datatables-{{ sg_datatables_view.name }}" class="{{ sg_datatables_view.options.classes }}" cellspacing="0">
     <thead>
         {% if true == individual_filtering %}
             {% if 'head' == sg_datatables_view.options.individualFilteringPosition or 'both' == sg_datatables_view.options.individualFilteringPosition%}

--- a/Resources/views/datatable/search.js.twig
+++ b/Resources/views/datatable/search.js.twig
@@ -47,3 +47,11 @@ $(selector).find("tr select.sg-datatables-individual-filtering").on("keyup chang
             .search(searchValue);
     drawTable();
 });
+
+{# responsive fix #}
+oTable.on( 'responsive-resize', function ( e, datatable, columns ) {
+    $.each(columns, function(index, isVisible){
+        !isVisible && $(selector+'-filterrow th').eq(index).hide();
+        isVisible && $(selector+'-filterrow th').eq(index).show();
+    });
+} );


### PR DESCRIPTION
The responsive extesions didn't work well for me. I tested it on bootstrap3 style only.
The solution is to remove width=100% on < table > and add event listener to hide invidual filtering rows.