### PR TITLE
Fix multiselect columns not creating multi-select actions

### DIFF
--- a/Datatable/Column/MultiselectColumn.php
+++ b/Datatable/Column/MultiselectColumn.php
@@ -201,6 +201,14 @@ class MultiselectColumn extends ActionColumn
         return $this;
     }
 
+    public function addAction(array $action)
+    {
+        $newAction = new MultiselectAction($this->datatableName);
+        $this->actions[] = $newAction->set($action);
+
+        return $this;
+    }
+
     /**
      * Get attributes.
      *


### PR DESCRIPTION
The `addAction()` method in the parent class is currently not overridden.  As a result, standard `Action`s are created without the necessary class used by JavaScript to handle click events.