### PR TITLE
Fix: recordsTotal calculation issue

### DIFF
--- a/Datatable/AbstractDatatable.php
+++ b/Datatable/AbstractDatatable.php
@@ -297,4 +297,12 @@ abstract class AbstractDatatable implements DatatableInterface
             throw new Exception('AbstractDatatable::validateName(): The result of the getName method can only contain letters, numbers, underscore and dashes.');
         }
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getCriteria()
+    {
+        return null;
+    }
 }

--- a/Datatable/DatatableInterface.php
+++ b/Datatable/DatatableInterface.php
@@ -11,6 +11,7 @@
 
 namespace Sg\DatatablesBundle\Datatable;
 
+use Doctrine\Common\Collections\Criteria;
 use Sg\DatatablesBundle\Datatable\Column\ColumnBuilder;
 
 use Doctrine\ORM\EntityManagerInterface;
@@ -118,6 +119,13 @@ interface DatatableInterface
      * @return string
      */
     public function getEntity();
+
+    /**
+     * Return Base criteria filter of a list
+     *
+     * @return Criteria
+     */
+    public function getCriteria();
 
     /**
      * Returns the name of this datatable view.

--- a/Resources/doc/query.md
+++ b/Resources/doc/query.md
@@ -57,6 +57,11 @@ public function indexAction(Request $request)
         $qb = $datatableQueryBuilder->getQb();
         $qb->andWhere('createdBy.username = :username');
         $qb->setParameter('username', 'root');
+        
+        //Or Using Base Query Implementation. This wiil 
+        $criteria = Criteria::create();
+        $criteria->andWhere(Criteria::expr()->eq('createdBy.username', 'root'));
+        $datatableQueryBuilder->setCriteria($criteria);
 
         return $responseService->getResponse();
     }

--- a/Resources/doc/query.md
+++ b/Resources/doc/query.md
@@ -61,7 +61,7 @@ public function indexAction(Request $request)
         //Or Using Base Query Implementation. This wiil 
         $criteria = Criteria::create();
         $criteria->andWhere(Criteria::expr()->eq('createdBy.username', 'root'));
-        $datatableQueryBuilder->setCriteria($criteria);
+        $datatableQueryBuilder->setBaseCriteria($criteria);
 
         return $responseService->getResponse();
     }

--- a/Response/DatatableQueryBuilder.php
+++ b/Response/DatatableQueryBuilder.php
@@ -11,6 +11,7 @@
 
 namespace Sg\DatatablesBundle\Response;
 
+use Doctrine\Common\Collections\Criteria;
 use Sg\DatatablesBundle\Datatable\Column\ColumnInterface;
 use Sg\DatatablesBundle\Datatable\Filter\FilterInterface;
 use Sg\DatatablesBundle\Datatable\DatatableInterface;
@@ -185,6 +186,9 @@ class DatatableQueryBuilder
      */
     private $useCountResultCacheArgs = [false];
 
+    /** @var Criteria */
+    private $baseCriteria = null;
+
     //-------------------------------------------------
     // Ctor. && Init column arrays
     //-------------------------------------------------
@@ -221,6 +225,8 @@ class DatatableQueryBuilder
         $this->options = $datatable->getOptions();
         $this->features = $datatable->getFeatures();
         $this->ajax = $datatable->getAjax();
+
+        $this->baseCriteria = $datatable->getCriteria();
 
         $this->initColumnArrays();
     }
@@ -315,6 +321,7 @@ class DatatableQueryBuilder
         $this->setSelectFrom();
         $this->setJoins($this->qb);
         $this->setWhere($this->qb);
+        $this->addCriteria($this->qb);
         $this->setOrderBy();
         $this->setLimit();
 
@@ -533,6 +540,9 @@ class DatatableQueryBuilder
         $qb = $this->em->createQueryBuilder();
         $qb->select('count(distinct '.$this->entityShortName.'.'.$this->rootEntityIdentifier.')');
         $qb->from($this->entityName, $this->entityShortName);
+
+        $this->addCriteria($qb);
+
         $query = $qb->getQuery();
         $query->useQueryCache($this->useCountQueryCache);
         call_user_func_array([$query, 'useResultCache'], $this->useCountResultCacheArgs);
@@ -849,5 +859,22 @@ class DatatableQueryBuilder
         }
 
         return $this;
+    }
+
+    /**
+     * @param Criteria $baseCriteria
+     * @return DatatableQueryBuilder
+     */
+    public function setBaseCriteria($baseCriteria)
+    {
+        $this->baseCriteria = $baseCriteria;
+        return $this;
+    }
+
+    private function addCriteria(QueryBuilder $qb)
+    {
+        if($this->baseCriteria !== null) {
+            $qb->addCriteria($this->baseCriteria);
+        }
     }
 }


### PR DESCRIPTION
To fix #639 we can use doctrine Criteria instead of modifying query builder. 

criteria is more reusable.
I've defined a baseCriteria  property to perform the base filter and other filter option should be used as it is.
This way the total count would be as per user expectation.