### PR TITLE
Add: allow set fetchJoinCollection on getResponse method

### DIFF
--- a/Response/DatatableResponse.php
+++ b/Response/DatatableResponse.php
@@ -118,11 +118,12 @@ class DatatableResponse
      *
      * @param bool $countAllResults
      * @param bool $outputWalkers
+     * @param bool $fetchJoinCollection
      *
      * @return JsonResponse
      * @throws Exception
      */
-    public function getResponse($countAllResults = true, $outputWalkers = false)
+    public function getResponse($countAllResults = true, $outputWalkers = false, $fetchJoinCollection = true)
     {
         if (null === $this->datatable) {
             throw new Exception('DatatableResponse::getResponse(): Set a Datatable class with setDatatable().');
@@ -132,7 +133,7 @@ class DatatableResponse
             throw new Exception('DatatableResponse::getResponse(): A DatatableQueryBuilder instance is needed. Call getDatatableQueryBuilder().');
         }
 
-        $paginator = new Paginator($this->datatableQueryBuilder->execute(), true);
+        $paginator = new Paginator($this->datatableQueryBuilder->execute(), $fetchJoinCollection);
         $paginator->setUseOutputWalkers($outputWalkers);
 
         $formatter = new DatatableFormatter();


### PR DESCRIPTION
I have a performance problem because it is not possible to change the $ fetchJoinColumn parameter when the Doctrine\ORM\Tools\Pagination\Paginator instance is created :( . 
According to [pagination](http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/pagination.html) this behavior is only necessary if you actually fetch join to-many collection, (in my case many-to-one). 

By the way awsome work. 👍 