### PR TITLE
Duplicate Id creation when you are in responsive

### DIFF
--- a/Resources/views/render/datetime.html.twig
+++ b/Resources/views/render/datetime.html.twig
@@ -11,7 +11,7 @@
 {%- endset -%}
 
 {%- set datetime_selector -%}
-    id="{{ datetime_id_selector }}"
+    class="{{ datetime_id_selector }}"
 {%- endset -%}
 
 {% if column_class_editable_selector is defined %}
@@ -30,9 +30,9 @@
             moment.locale("{{ app.request.locale }}");
 
             {% if timeago is same as(false) %}
-                $("#{{ datetime_id_selector }}").html(moment.unix({{ data|date('U') }}).format("{{ date_format }}"));
+                $(".{{ datetime_id_selector }}").html(moment.unix({{ data|date('U') }}).format("{{ date_format }}"));
             {% else %}
-                $("#{{ datetime_id_selector }}").html(moment.unix({{ data|date('U') }}).fromNow());
+                $(".{{ datetime_id_selector }}").html(moment.unix({{ data|date('U') }}).fromNow());
             {% endif %}
         });
     </script>


### PR DESCRIPTION
When you are in responsive mode (the default one) the cell is duplicated.

That way the id is duplicated too, and the javascript doesn't work anymore.

Replacing the definition by a class will fix that bug