### PR TITLE
split getResponse method to allow access to not encoded response data

### DIFF
--- a/Response/DatatableResponse.php
+++ b/Response/DatatableResponse.php
@@ -114,16 +114,16 @@ class DatatableResponse
     //-------------------------------------------------
 
     /**
-     * Get response.
+     * Get response data as array.
      *
      * @param bool $countAllResults
      * @param bool $outputWalkers
      * @param bool $fetchJoinCollection
      *
-     * @return JsonResponse
+     * @return array
      * @throws Exception
      */
-    public function getResponse($countAllResults = true, $outputWalkers = false, $fetchJoinCollection = true)
+    public function getData($countAllResults = true, $outputWalkers = false, $fetchJoinCollection = true)
     {
         if (null === $this->datatable) {
             throw new Exception('DatatableResponse::getResponse(): Set a Datatable class with setDatatable().');
@@ -145,7 +145,22 @@ class DatatableResponse
             'recordsTotal' => true === $countAllResults ? (int) $this->datatableQueryBuilder->getCountAllResults() : 0,
         );
 
-        return new JsonResponse(array_merge($outputHeader, $formatter->getOutput()));
+        return array_merge($outputHeader, $formatter->getOutput());
+    }
+
+    /**
+     * Get response.
+     *
+     * @param bool $countAllResults
+     * @param bool $outputWalkers
+     * @param bool $fetchJoinCollection
+     *
+     * @return JsonResponse
+     * @throws Exception
+     */
+    public function getResponse($countAllResults = true, $outputWalkers = false, $fetchJoinCollection = true)
+    {
+        return new JsonResponse($this->getData($countAllResults, $outputWalkers, $fetchJoinCollection));
     }
 
     //-------------------------------------------------


### PR DESCRIPTION
Pull request to fix #671 