### PR TITLE
Use caret operator for composer dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,10 +20,10 @@
     "require": {
         "php": ">=5.5.9",
         "symfony/framework-bundle": "~3.0",
-        "doctrine/orm": "^2.5",
+        "doctrine/orm": "~2.5",
         "symfony/options-resolver": "~3.0",
         "symfony/property-access": "~3.0",
-        "friendsofsymfony/jsrouting-bundle": "1.6.*"
+        "friendsofsymfony/jsrouting-bundle": "~1.6"
     },
     "autoload": {
         "psr-4": { "Sg\\DatatablesBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
     },
     "require": {
         "php": ">=5.5.9",
-        "symfony/framework-bundle": "~3.0",
-        "doctrine/orm": "~2.5",
-        "symfony/options-resolver": "~3.0",
-        "symfony/property-access": "~3.0",
-        "friendsofsymfony/jsrouting-bundle": "~1.6"
+        "symfony/framework-bundle": "^3.0",
+        "doctrine/orm": "^2.5",
+        "symfony/options-resolver": "^3.0",
+        "symfony/property-access": "^3.0",
+        "friendsofsymfony/jsrouting-bundle": "^1.6"
     },
     "autoload": {
         "psr-4": { "Sg\\DatatablesBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "doctrine/orm": "^2.5",
         "symfony/options-resolver": "~3.0",
         "symfony/property-access": "~3.0",
-        "friendsofsymfony/jsrouting-bundle": "1.6.0"
+        "friendsofsymfony/jsrouting-bundle": "1.6.*"
     },
     "autoload": {
         "psr-4": { "Sg\\DatatablesBundle\\": "" }


### PR DESCRIPTION
This package requires `"friendsofsymfony/jsrouting-bundle": "1.6.0"`, while there is a bugfix release available.

I've updated other dependencies too, to have a consistent syntax. This has no impact on the required version because `^1.0 === ~1.0`