### PR TITLE
Replaced `$isAjax` by `$request->isXmlHttpRequest()` in documentation

### DIFF
--- a/Resources/doc/query.md
+++ b/Resources/doc/query.md
@@ -44,7 +44,7 @@ public function indexAction(Request $request)
 {
     // ...
 
-    if ($isAjax) {
+    if ($request->isXmlHttpRequest()) {
         $responseService = $this->get('sg_datatables.response');
         $responseService->setDatatable($datatable);
 


### PR DESCRIPTION
Replaced `$isAjax` by `$request->isXmlHttpRequest()`