### PR TITLE
Use js escaping for buttons 'text' property, so it can contain html tags

### DIFF
--- a/Resources/views/datatable/button.html.twig
+++ b/Resources/views/datatable/button.html.twig
@@ -50,7 +50,7 @@
         namespace: "{{ button.namespace }}",
     {% endif %}
     {% if button.text is defined and button.text is not same as(null) %}
-        text: "{{ button.text }}",
+        text: "{{ button.text|e('js') }}",
     {% endif %}
     {% if button.titleAttr is defined and button.titleAttr is not same as(null) %}
         titleAttr: "{{ button.titleAttr }}",


### PR DESCRIPTION
 -- corrected branch original PR #629 ---

Hi,
i suggest to change the default html escaping of the buttons text in the twig template, so that it's possible to use html tags for styling the text eg. with an icon like this:
```
$this->extensions->set(array(

       		'buttons' => array(
            	'create_buttons' => array(
                	array(
                    	'action' => array(
                        	'template' => ':post:action.js.twig',
                        	//'vars' => array('id' => '2', 'test' => 'new value'),
                    	),
                    	'text' => '<i class="fa fa-plus"></i> New',
                	),
            	),
       		),
        ));
```