### PR TITLE
Added missing getColumnBuilder() call

### DIFF
--- a/Twig/DatatableTwigExtension.php
+++ b/Twig/DatatableTwigExtension.php
@@ -182,7 +182,7 @@ class DatatableTwigExtension extends Twig_Extension
         $searchColumn = $this->accessor->getValue($filter, 'searchColumn');
 
         if (null !== $searchColumn) {
-            $columns = $datatable->getColumnNames();
+            $columns = $datatable->getColumnBuilder()->getColumnNames();
             $searchColumnIndex = $columns[$searchColumn];
         } else {
             $searchColumnIndex = $index;


### PR DESCRIPTION
Otherwise call on this line fails, because method getColumnBuilder() is not forced to be implemented on Datatable.