### PR TITLE
Fix individual filtering in combination with scrollX

### DIFF
--- a/Resources/views/datatable/search.js.twig
+++ b/Resources/views/datatable/search.js.twig
@@ -37,9 +37,9 @@ var search = $.fn.dataTable.util.throttle(
         options.searchDelay
 );
 
-$(selector).find("tr input.sg-datatables-individual-filtering").on("keyup change", search);
+$(oTable.table().container()).find("tr input.sg-datatables-individual-filtering").on("keyup change", search);
 
-$(selector).find("tr select.sg-datatables-individual-filtering").on("keyup change", function(event) {
+$(oTable.table().container()).find("tr select.sg-datatables-individual-filtering").on("keyup change", function(event) {
     var searchValue = $(this).val();
     searchValue = searchValue ? searchValue.toString() : '';
     oTable


### PR DESCRIPTION
Fix individual filtering in combination with horizontal scrolling byusing the Datatable instance and not a predefined ID as selector.

Bug: When individual filtering used on a table with `scrollX = true` the column filters don't work. The code in search.js.twig searches for the input & select fields in the datatable (by the id of the table). Because of the scrollX, the table has been split up in 2 different tables (e.g. one table for scrollHead and another table for scrollBody). The input fields are now outside the 'selector' and will not work. 

To solve this the selector should be changed to the wrapper/container. However this is different for tables with or without scrollX. Like the example on https://datatables.net/extensions/fixedcolumns/examples/styling/col_filter.html I've now used `oTable.table().container()` as selector. This will work with and without `scrollX = true`.