### PR TITLE
Fix for Multiselect Column on Symfony 4

### DIFF
--- a/Datatable/Column/MultiselectColumn.php
+++ b/Datatable/Column/MultiselectColumn.php
@@ -211,6 +211,7 @@ class MultiselectColumn extends ActionColumn
     {
         $newAction = new MultiselectAction($this->datatableName);
         $this->actions[] = $newAction->set($action);
+        
         return $this;
     }
 

--- a/Resources/translations/messages.sk.yml
+++ b/Resources/translations/messages.sk.yml
@@ -1,0 +1,12 @@
+sg:
+    datatables:
+        confirmMessage: "Ste si istý?"
+        selectError: "Musíte vybrať aspoň jeden prvok."
+        actions:
+            title: "Akcie"
+            show: "Zobraziť"
+            edit: "Upraviť"
+        daterange:
+            apply: "Aplikovať"
+            cancel: "Zrušiť"
+            format: "DD.MM.YYYY"


### PR DESCRIPTION
Symfony 4's PropertyAccessor uses primary add* method for adding properties, not set*. Since MultiselectColumn is derived from ActionColumn and MultiselectColumn didn't have a addAction method, PropertyAccessor uses addAction method from ActionColumn class, that creates Action objects, not MultiselectAction objects.