### PR TITLE
[Extensions Buttons] Allow using a template for body format when exporting

### DIFF
--- a/Resources/views/datatable/button.html.twig
+++ b/Resources/views/datatable/button.html.twig
@@ -57,7 +57,7 @@
     {% endif %}
     {% if button.buttonOptions is defined and button.buttonOptions is not same as(null) %}
         {% for key, option in button.buttonOptions %}
-            {{ key }}: {{ option|json_encode|raw }},
+            {{ key }}: {{ option|sg_datatables_option_encode|raw }},
         {% endfor %}
     {% endif %}
 },

--- a/Twig/DatatableTwigExtension.php
+++ b/Twig/DatatableTwigExtension.php
@@ -103,6 +103,7 @@ class DatatableTwigExtension extends Twig_Extension
     {
         return array(
             new Twig_SimpleFilter('sg_datatables_bool_var', array($this, 'boolVar')),
+            new Twig_SimpleFilter('sg_datatables_option_encode', array($this, 'optionEncode'), ['needs_environment' => true]),
         );
     }
 
@@ -277,5 +278,27 @@ class DatatableTwigExtension extends Twig_Extension
         } else {
             return 'false';
         }
+    }
+
+
+    /**
+     * Renders: A json encode, except a template for the body. Useful for export pdf
+     *
+     * @param mixed $value
+     *
+     * @return string
+     */
+    public function optionEncode(Twig_Environment $twig, $value)
+    {
+        $value = json_encode($value);
+
+        preg_match('@\{\"template\"\:\".*?\"\}@si', $value, $matches);
+
+        foreach ($matches as $match){
+            $template = json_decode($match, true)["template"];
+            $value = str_replace($match, $twig->render($template), $value);
+        }
+
+        return $value;
     }
 }


### PR DESCRIPTION
I've started this pull request as the datatime was rendered incorrectly (moment javascript was displayed when exporting a datatime field rather than the actual information). This may have been fixable in another way, but having the option to use a template for the function of the body is valuable.

Example of how to use.

**Datatable.php**
`$this->extensions->set(array(
           'buttons' => array(
               'show_buttons' => array('copy', 'print', 'excel'),    // built-in buttons
                   array(
                       'extend' => 'pdf',
                       'text' => 'my pdf',
                       'button_options' => array(
                           'exportOptions' => array(
                               'format' => array(
                                   'body' => array(
                                       'template' => '@App/Admin/user-format.partial.twig',
                                   ),
                               ),
                           ),
                       ),
                   ),
           ),
       )));`

**App/Admin/user-format.partial.twig**
`function ( data, row, column, node ) {
    if (column === 3){
        var date = eval(data.substring(data.lastIndexOf("html(")+5,data.lastIndexOf("))")+1));
        return date === undefined ? '' : date;
    }
    return $(data).text();
}`