### PR TITLE
Removed SensioGeneratorBundle as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "php": ">=5.5.9",
         "symfony/framework-bundle": "^3.0|^4.0",
         "doctrine/orm": "^2.5",
+        "doctrine/doctrine-bundle": "^1.6",
         "symfony/options-resolver": "^3.0|^4.0",
         "symfony/property-access": "^3.0|^4.0",
         "friendsofsymfony/jsrouting-bundle": "^1.6|^2.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/options-resolver": "^3.0|^4.0",
         "symfony/property-access": "^3.0|^4.0",
         "friendsofsymfony/jsrouting-bundle": "^1.6|^2.0",
-        "sensio/generator-bundle": "^3.0",
+        "sensio/generator-bundle": "^3.0"
     },
     "autoload": {
         "psr-4": { "Sg\\DatatablesBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "doctrine/orm": "^2.5",
         "symfony/options-resolver": "^3.0|^4.0",
         "symfony/property-access": "^3.0|^4.0",
-        "friendsofsymfony/jsrouting-bundle": "^1.6|^2.0"
+        "friendsofsymfony/jsrouting-bundle": "^1.6|^2.0",
+        "sensio/generator-bundle": "^3.0",
     },
     "autoload": {
         "psr-4": { "Sg\\DatatablesBundle\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -21,11 +21,9 @@
         "php": ">=5.5.9",
         "symfony/framework-bundle": "^3.0|^4.0",
         "doctrine/orm": "^2.5",
-        "doctrine/doctrine-bundle": "^1.6",
         "symfony/options-resolver": "^3.0|^4.0",
         "symfony/property-access": "^3.0|^4.0",
-        "friendsofsymfony/jsrouting-bundle": "^1.6|^2.0",
-        "sensio/generator-bundle": "^3.0"
+        "friendsofsymfony/jsrouting-bundle": "^1.6|^2.0"
     },
     "autoload": {
         "psr-4": { "Sg\\DatatablesBundle\\": "" }


### PR DESCRIPTION
Fixes #725. 

To be honest, this is a real quick and dirty solution and I'm not proud of it. There must be a better solution that just copying methods from one class to another, but I don't know.