### PR TITLE
Action label closure

### DIFF
--- a/Datatable/Action/Action.php
+++ b/Datatable/Action/Action.php
@@ -176,7 +176,7 @@ class Action
         $resolver->setAllowedTypes('route', array('null', 'string'));
         $resolver->setAllowedTypes('route_parameters', array('null', 'array', 'Closure'));
         $resolver->setAllowedTypes('icon', array('null', 'string'));
-        $resolver->setAllowedTypes('label', array('null', 'string'));
+        $resolver->setAllowedTypes('label', array('null', 'string', 'Closure'));
         $resolver->setAllowedTypes('confirm', 'bool');
         $resolver->setAllowedTypes('confirm_message', array('null', 'string'));
         $resolver->setAllowedTypes('attributes', array('null', 'array', 'Closure'));
@@ -288,6 +288,22 @@ class Action
         $this->label = $label;
 
         return $this;
+    }
+
+    /**
+     * Call label closure.
+     *
+     * @param array $row
+     *
+     * @return string
+     */
+    public function callLabelClosure(array $row = array())
+    {
+        if ($this->label instanceof Closure) {
+            return call_user_func($this->label, $row);
+        }
+
+        return $this->label;
     }
 
     /**

--- a/Datatable/Column/ActionColumn.php
+++ b/Datatable/Column/ActionColumn.php
@@ -83,6 +83,7 @@ class ActionColumn extends AbstractColumn
         $parameters = array();
         $attributes = array();
         $values = array();
+        $labels = array();
 
         /** @var Action $action */
         foreach ($this->actions as $actionKey => $action) {
@@ -136,12 +137,15 @@ class ActionColumn extends AbstractColumn
                     $values[$actionKey] = null;
                 }
             }
+
+            $labels[$actionKey] = $action->callLabelClosure($row);
         }
 
         $row[$this->getIndex()] = $this->twig->render(
             $this->getCellContentTemplate(),
             array(
                 'actions' => $this->actions,
+                'labels' => $labels,
                 'route_parameters' => $parameters,
                 'attributes' => $attributes,
                 'values' => $values,

--- a/Resources/doc/columns.md
+++ b/Resources/doc/columns.md
@@ -434,21 +434,21 @@ A Column to display CRUD action labels or buttons.
 
 ### Action options
 
-| Option              | Type                   | Default | Required | Description |
-|---------------------|------------------------|---------|----------|-------------|
-| route               | null or string         | null    |          | The name of the Action route. |
-| route_parameters    | null, array or Closure | null    |          | The route parameters. |
-| icon                | null or string         | null    |          | An icon for the Action. |
-| label               | null or string         | null    |          | A label for the Action. |
-| confirm             | bool                   | false   |          | Show confirm message if true. |
-| confirm_message     | null or string         | null    |          | The confirm message. |
-| attributes          | null, array or Closure | null    |          | HTML Tag attributes (except 'href' and 'value'). |
-| button              | bool                   | false   |          | Render a button instead of a link. |
-| button_value        | null or string         | null    |          | The button value. |
-| button_value_prefix | bool                   | false   |          | Use the Datatable-Name as prefix for the button value. |
-| render_if           | null or Closure        | null    |          | Render an Action only if conditions are TRUE. |
-| start_html          | null or string         | null    |          | HTML code before the <a> Tag. |
-| end_html            | null or string         | null    |          | HTML code after the <a> Tag. |
+| Option              | Type                    | Default | Required | Description |
+|---------------------|-------------------------|---------|----------|-------------|
+| route               | null or string          | null    |          | The name of the Action route. |
+| route_parameters    | null, array or Closure  | null    |          | The route parameters. |
+| icon                | null or string          | null    |          | An icon for the Action. |
+| label               | null, string or Closure | null    |          | A label for the Action. |
+| confirm             | bool                    | false   |          | Show confirm message if true. |
+| confirm_message     | null or string          | null    |          | The confirm message. |
+| attributes          | null, array or Closure  | null    |          | HTML Tag attributes (except 'href' and 'value'). |
+| button              | bool                    | false   |          | Render a button instead of a link. |
+| button_value        | null or string          | null    |          | The button value. |
+| button_value_prefix | bool                    | false   |          | Use the Datatable-Name as prefix for the button value. |
+| render_if           | null or Closure         | null    |          | Render an Action only if conditions are TRUE. |
+| start_html          | null or string          | null    |          | HTML code before the <a> Tag. |
+| end_html            | null or string          | null    |          | HTML code after the <a> Tag. |
 
 ### Example
 
@@ -534,6 +534,16 @@ $this->columnBuilder
                 },
                 'start_html' => '<div class="start_show_action">',
                 'end_html' => '</div>',
+            ),
+            array(
+                'route' => 'comments_show',
+                'route_parameters' => array(
+                    'id' => 'id',
+                ),
+                'label' => function($row) {
+                    return sprintf('Show %s comments', '$row['comment_count']); // 'comment_count' may be a virtual column
+                },
+                'confirm' => false,
             ),
         ),
     ))

--- a/Resources/views/render/action.html.twig
+++ b/Resources/views/render/action.html.twig
@@ -8,7 +8,7 @@
  #}
 {% import _self as macros %}
 
-{% macro link_title(action) %}
+{% macro link_title(action, label) %}
     {% if action.label is same as(null) and action.icon is same as(null) %}
         {% if action.route is not same as(null) %}
             {{ action.route }}
@@ -16,7 +16,7 @@
             null
         {% endif %}
     {% else %}
-        <span class="{{ action.icon }}"></span> {{ action.label }}
+        <span class="{{ action.icon }}"></span> {{ label }}
     {% endif %}
 {% endmacro %}
 
@@ -65,13 +65,13 @@
         {% if action.button is same as(false) %}
             {{ action.startHtml|raw }}
             <a {{ macros.href(action, route_parameters[actionKey]) }} {{ macros.attributes(attributes[actionKey]) }} {{ macros.confirm_dialog(action) }}>
-                {{ macros.link_title(action) }}
+                {{ macros.link_title(action, labels[actionKey]) }}
             </a>
             {{ action.endHtml|raw }}
         {% else %}
             {{ action.startHtml|raw }}
             <button type="button" {{ macros.value(values[actionKey]) }} {{ macros.attributes(attributes[actionKey]) }} {{ macros.confirm_dialog(action) }}>
-                {{ macros.link_title(action) }}
+                {{ macros.link_title(action, labels[actionKey]) }}
             </button>
             {{ action.endHtml|raw }}
         {% endif %}


### PR DESCRIPTION
Using a closure for an action label makes it possible to use values from other columns in link titles (also buttons), see example in `columns.md `.