### PR TITLE
Override QueryBuilder alias

### DIFF
--- a/Resources/doc/query.md
+++ b/Resources/doc/query.md
@@ -62,6 +62,33 @@ public function indexAction(Request $request)
 }
 ```
 
+If you need to override the entity alias, set the entity short name.
+
+``` php
+public function indexAction(Request $request)
+{
+    // ...
+
+    if ($request->isXmlHttpRequest()) {
+        $responseService = $this->get('sg_datatables.response');
+        $responseService->setDatatable($datatable);
+
+        $datatableQueryBuilder = $responseService->getDatatableQueryBuilder();
+        $datatableQueryBuilder->setEntityShortName('p');
+        
+        /** @var QueryBuilder $qb */
+        $qb = $datatableQueryBuilder->getQb();
+        $qb->andWhere('createdBy.username = :username');
+        $qb->setParameter('username', 'root');
+        $qb->andWhere('p.deleted = 0');
+
+        return $responseService->getResponse();
+    }
+
+    // ...
+}
+```
+
 ## 2. Subqueries
 
 Sometimes it is needed to count the number of rows or concatenate multiple fields.

--- a/Response/DatatableQueryBuilder.php
+++ b/Response/DatatableQueryBuilder.php
@@ -215,11 +215,6 @@ class DatatableQueryBuilder
 
         $this->columns = $datatable->getColumnBuilder()->getColumns();
 
-        $this->selectColumns = array();
-        $this->searchColumns = array();
-        $this->orderColumns = array();
-        $this->joins = array();
-
         $this->options = $datatable->getOptions();
         $this->features = $datatable->getFeatures();
         $this->ajax = $datatable->getAjax();
@@ -234,6 +229,11 @@ class DatatableQueryBuilder
      */
     private function initColumnArrays()
     {
+        $this->selectColumns = array();
+        $this->searchColumns = array();
+        $this->orderColumns = array();
+        $this->joins = array();
+
         foreach ($this->columns as $key => $column) {
             $dql = $this->accessor->getValue($column, 'dql');
             $data = $this->accessor->getValue($column, 'data');
@@ -774,6 +774,23 @@ class DatatableQueryBuilder
         }
 
         return $isReservedKeyword ? "_{$entityShortName}" : $entityShortName;
+    }
+
+    /**
+     * Set entity short name.
+     *
+     * @param string $entityShortName
+     *
+     * @return $this
+     */
+    public function setEntityShortName($entityShortName)
+    {
+        $this->entityShortName = $entityShortName;
+
+        $this->qb = $this->em->createQueryBuilder()->from($this->entityName, $this->entityShortName);
+        $this->initColumnArrays();
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
As described in #778 it's sometimes necessary to set the QueryBuilder alias to be able to customize a query without limitations.