### PR TITLE
Add custom ajax data

### DIFF
--- a/Datatable/Callbacks.php
+++ b/Datatable/Callbacks.php
@@ -93,6 +93,13 @@ class Callbacks
     protected $rowCallback;
 
     /**
+     * Callback that can be used to add custom ajax data.
+     *
+     * @var null|array
+     */
+    protected $serverParamsCallback;
+
+    /**
      * Callback that defines where and how a saved state should be loaded.
      *
      * @var null|array
@@ -162,6 +169,7 @@ class Callbacks
             'init_complete' => null,
             'pre_draw_callback' => null,
             'row_callback' => null,
+            'server_params_callback' => null,
             'state_load_callback' => null,
             'state_loaded' => null,
             'state_load_params' => null,
@@ -178,6 +186,7 @@ class Callbacks
         $resolver->setAllowedTypes('init_complete', array('null', 'array'));
         $resolver->setAllowedTypes('pre_draw_callback', array('null', 'array'));
         $resolver->setAllowedTypes('row_callback', array('null', 'array'));
+        $resolver->setAllowedTypes('server_params_callback', array('null', 'array'));
         $resolver->setAllowedTypes('state_load_callback', array('null', 'array'));
         $resolver->setAllowedTypes('state_loaded', array('null', 'array'));
         $resolver->setAllowedTypes('state_load_params', array('null', 'array'));
@@ -439,6 +448,34 @@ class Callbacks
         }
 
         $this->rowCallback = $rowCallback;
+
+        return $this;
+    }
+
+    /**
+     * Get serverParamsCallback.
+     *
+     * @return array|null
+     */
+    public function getServerParamsCallback()
+    {
+        return $this->serverParamsCallback;
+    }
+
+    /**
+     * Set serverParamsCallback.
+     *
+     * @param array|null $serverParamsCallback
+     *
+     * @return $this
+     */
+    public function setServerParamsCallback($serverParamsCallback)
+    {
+        if (is_array($serverParamsCallback)) {
+            $this->validateArrayForTemplateAndOther($serverParamsCallback);
+        }
+
+        $this->serverParamsCallback = $serverParamsCallback;
 
         return $this;
     }

--- a/Resources/doc/callbacks.md
+++ b/Resources/doc/callbacks.md
@@ -1,21 +1,22 @@
 # Callbacks
 
-| Callback            | Type          | Default | Description |
-|---------------------|---------------|---------|-------------|
-| created_row         | array or null | null    | Callback for whenever a TR element is created for the table's body.|
-| draw_callback       | array or null | null    | Function that is called every time DataTables performs a draw.|
-| footer_callback     | array or null | null    | Footer display callback function.|
-| format_number       | array or null | null    | Number formatting callback function.|
-| header_callback     | array or null | null    | Header display callback function.|
-| info_callback       | array or null | null    | Table summary information display callback.|
-| init_complete       | array or null | null    | Initialisation complete callback.|
-| pre_draw_callback   | array or null | null    | Pre-draw callback.|
-| row_callback        | array or null | null    | Row draw callback.|
-| state_load_callback | array or null | null    | Callback that defines where and how a saved state should be loaded.|
-| state_loaded        | array or null | null    | State loaded callback.|
-| state_load_params   | array or null | null    | State loaded - data manipulation callback.|
-| state_save_callback | array or null | null    | Callback that defines how the table state is stored and where.|
-| state_save_params   | array or null | null    | State save - data manipulation callback.|
+| Callback               | Type          | Default | Description |
+|------------------------|---------------|---------|-------------|
+| created_row            | array or null | null    | Callback for whenever a TR element is created for the table's body.|
+| draw_callback          | array or null | null    | Function that is called every time DataTables performs a draw.|
+| footer_callback        | array or null | null    | Footer display callback function.|
+| format_number          | array or null | null    | Number formatting callback function.|
+| header_callback        | array or null | null    | Header display callback function.|
+| info_callback          | array or null | null    | Table summary information display callback.|
+| init_complete          | array or null | null    | Initialisation complete callback.|
+| pre_draw_callback      | array or null | null    | Pre-draw callback.|
+| row_callback           | array or null | null    | Row draw callback.|
+| server_params_callback | array or null | null    | Callback that can be used to add custom ajax data.|
+| state_load_callback    | array or null | null    | Callback that defines where and how a saved state should be loaded.|
+| state_loaded           | array or null | null    | State loaded callback.|
+| state_load_params      | array or null | null    | State loaded - data manipulation callback.|
+| state_save_callback    | array or null | null    | Callback that defines how the table state is stored and where.|
+| state_save_params      | array or null | null    | State save - data manipulation callback.|
 
 **Example**
 
@@ -33,6 +34,9 @@ class PostDatatable extends AbstractDatatable
             ),
             'init_complete' => array(
                 'template' => ':post:init.js.twig',
+            ),
+            'server_params_callback' => array(
+                'template' => ':post:server_params_callback.js.twig',
             ),
         ));
 
@@ -63,5 +67,14 @@ function rowCallback(nRow, aData, index) {
 
 function init(settings, json) {
     alert('Init complete.');
+}
+```
+
+``` js
+// server_params_callback.js.twig
+
+function serverParamsCallback(d) {
+    var formData = {'some': 'data'}; // e.g. serialize a form here
+    $.extend( d, formData ); // Attention: Do not override datatable ajax data!
 }
 ```

--- a/Resources/views/datatable/ajax.html.twig
+++ b/Resources/views/datatable/ajax.html.twig
@@ -11,10 +11,20 @@
         "url": "{{ sg_datatables_view.ajax.url|raw }}",
     {% endif %}
     "type": "{{ sg_datatables_view.ajax.type }}",
-    {% if sg_datatables_view.ajax.data is not same as(null) %}
-        "data": function ( d ) {
-            callbacks.serverParamsCallback($.extend(true, d, {{ sg_datatables_view.ajax.data|raw }}));
-        },
+    {% if sg_datatables_view.callbacks.serverParamsCallback is not same as(null) %}
+        {% if sg_datatables_view.ajax.data is not same as(null) %}
+            "data": function (d) {
+                callbacks.serverParamsCallback($.extend(true, d, {{ sg_datatables_view.ajax.data|raw }}));
+            },
+        {% else %}
+            "data": function (d) {
+                callbacks.serverParamsCallback(d);
+            },
+        {% endif %}
+    {% else %}
+        {% if sg_datatables_view.ajax.data is not same as(null) %}
+            "data": {{ sg_datatables_view.ajax.data|raw }},
+        {% endif %}
     {% endif %}
 {% endset %}
 

--- a/Resources/views/datatable/ajax.html.twig
+++ b/Resources/views/datatable/ajax.html.twig
@@ -12,7 +12,9 @@
     {% endif %}
     "type": "{{ sg_datatables_view.ajax.type }}",
     {% if sg_datatables_view.ajax.data is not same as(null) %}
-        "data": {{ sg_datatables_view.ajax.data|raw }},
+        "data": function ( d ) {
+            callbacks.serverParamsCallback($.extend(true, d, {{ sg_datatables_view.ajax.data|raw }}));
+        },
     {% endif %}
 {% endset %}
 

--- a/Resources/views/datatable/callbacks.html.twig
+++ b/Resources/views/datatable/callbacks.html.twig
@@ -78,6 +78,14 @@
     {% endif %}
     "rowCallback": {% include sg_datatables_view.callbacks.rowCallback['template'] with vars%},
 {% endif %}
+{% if sg_datatables_view.callbacks.serverParamsCallback is not same as(null) %}
+    {% if sg_datatables_view.callbacks.serverParamsCallback['vars'] is defined %}
+        {% set vars = sg_datatables_view.callbacks.serverParamsCallback['vars'] %}
+    {% else %}
+        {% set vars = {} %}
+    {% endif %}
+    "serverParamsCallback": {% include sg_datatables_view.callbacks.serverParamsCallback['template'] with vars %},
+{% endif %}
 {% if sg_datatables_view.callbacks.stateLoadCallback is not same as(null) %}
     {% if sg_datatables_view.callbacks.stateLoadCallback['vars'] is defined %}
         {% set vars = sg_datatables_view.callbacks.stateLoadCallback['vars'] %}

--- a/Resources/views/datatable/datatable_js.html.twig
+++ b/Resources/views/datatable/datatable_js.html.twig
@@ -20,6 +20,10 @@
             {% include '@SgDatatables/datatable/language.html.twig' %}
         };
 
+        var callbacks = {
+            {% include '@SgDatatables/datatable/callbacks.html.twig' %}
+        };
+
         var ajax = {
             {% include '@SgDatatables/datatable/ajax.html.twig' %}
         };
@@ -30,10 +34,6 @@
 
         var features = {
             {% include '@SgDatatables/datatable/features.html.twig' %}
-        };
-
-        var callbacks = {
-            {% include '@SgDatatables/datatable/callbacks.html.twig' %}
         };
 
         var extensions = {


### PR DESCRIPTION
Like described in #780 it's useful to be able to add custom ajax data. I implemented a callback according to datatable's `fnServerParams` callback. I know it's legacy, but how else could we add data to the ajax request (on client-side) via js if not using a callback? If you have another idea, please let me know.