### PR TITLE
bugfix: multiple select should search by search item

### DIFF
--- a/Datatable/Filter/SelectFilter.php
+++ b/Datatable/Filter/SelectFilter.php
@@ -70,7 +70,7 @@ class SelectFilter extends AbstractFilter
 
             foreach ($searchValues as $searchItem) {
                 $this->setSelectSearchType($searchItem);
-                $orExpr->add($this->getExpression($qb->expr()->andX(), $qb, $this->searchType, $searchField, $searchValue, $searchTypeOfField, $parameterCounter));
+                $orExpr->add($this->getExpression($qb->expr()->andX(), $qb, $this->searchType, $searchField, $searchItem, $searchTypeOfField, $parameterCounter));
             }
 
             return $andExpr->add($orExpr);


### PR DESCRIPTION
I think this was a typo:
Whene multiple search is true, it should search by $searchItem and not by $searchValue