### PR TITLE
Fixed deprecated Route annotation

### DIFF
--- a/Controller/DatatableController.php
+++ b/Controller/DatatableController.php
@@ -17,8 +17,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
 use Symfony\Component\Security\Core\Exception\AccessDeniedException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Symfony\Component\Routing\Annotation\Route;
 use Doctrine\DBAL\Types\Type;
 use Exception;
 use DateTime;
@@ -39,8 +38,7 @@ class DatatableController extends Controller
      *
      * @param Request $request
      *
-     * @Route("/datatables/edit/field", name="sg_datatables_edit")
-     * @Method("POST")
+     * @Route("/datatables/edit/field", method={"POST"}, name="sg_datatables_edit")
      *
      * @return Response
      * @throws Exception


### PR DESCRIPTION
Sensio\Bundle\FrameworkExtraBundle\Configuration\Method and Route have been deprecated in 4.1+

Fixed with new Symfony\Component\Routing\Annotation\Route for 4.1+

HOWEVER, with this change, older code would break.