### PR TITLE
Get fields from database without sending them to browser

### DIFF
--- a/Datatable/Column/AbstractColumn.php
+++ b/Datatable/Column/AbstractColumn.php
@@ -290,6 +290,14 @@ abstract class AbstractColumn implements ColumnInterface
      */
     protected $originalTypeOfField;
 
+    /**
+     * If the field is sent in the response, to show in the webpage
+     * Is set in the ColumnBuilder.
+     * Default: true
+     *
+     * @var bool
+     */
+    protected $sentInResponse;
     //-------------------------------------------------
     // Options
     //-------------------------------------------------
@@ -323,6 +331,7 @@ abstract class AbstractColumn implements ColumnInterface
             'join_type' => 'leftJoin',
             'type_of_field' => null,
             'responsive_priority' => null,
+            'sent_in_response' => true,
         ));
 
         $resolver->setAllowedTypes('cell_type', array('null', 'string'));
@@ -343,6 +352,7 @@ abstract class AbstractColumn implements ColumnInterface
         $resolver->setAllowedTypes('join_type', 'string');
         $resolver->setAllowedTypes('type_of_field', array('null', 'string'));
         $resolver->setAllowedTypes('responsive_priority', array('null', 'int'));
+        $resolver->setAllowedTypes('sent_in_response', array('bool'));
 
         $resolver->setAllowedValues('cell_type', array(null, 'th', 'td'));
         $resolver->setAllowedValues('join_type', array(null, 'join', 'leftJoin', 'innerJoin'));
@@ -1075,4 +1085,29 @@ abstract class AbstractColumn implements ColumnInterface
 
         return $this;
     }
+
+    /**
+     * Get sentInResponse.
+     *
+     * @return bool
+     */
+    public function getSentInResponse()
+    {
+        return $this->sentInResponse;
+    }
+
+    /**
+     * Set sentIntResponse.
+     *
+     * @param bool $sentInResponse
+     *
+     * @return $this
+     */
+    public function setSentInResponse($sentInResponse)
+    {
+        $this->sentInResponse = $sentInResponse;
+
+        return $this;
+    }
+
 }

--- a/Resources/doc/columns.md
+++ b/Resources/doc/columns.md
@@ -40,6 +40,7 @@ With 'null' initialized options uses the default value of the DataTables plugin.
 | searchable          | bool               | true              |          | Enable or disable filtering on the data in this column. |
 | title               | null or string     | null              |          | Set the column title. |
 | visible             | bool               | true              |          | Enable or disable the display of this column. |
+| sent_in_response    | bool               | true              |          | When set to `false`, allows to access to this field in the `$row` array in Closures without sending this column to the browser (parameter `visible` set to `false` only hides the column in the rendered table). |
 | width               | null or string     | null              |          | Column width assignment. |
 | add_if              | null or Closure    | null              |          | Add column only if conditions are TRUE. |
 | join_type           | string             | 'leftJoin'        |          | Join type (default: 'leftJoin'), if the column represents an association. |

--- a/Resources/views/column/column.html.twig
+++ b/Resources/views/column/column.html.twig
@@ -23,11 +23,6 @@
         {% if column.width is not same as(null) %}
             "width": "{{ column.width }}",
         {% endif %}
-        {% block title %}
-            {% if column.title is not same as(null) %}
-                "title": "{{ column.title|raw }}",
-            {% endif %}
-        {% endblock %}
         {% if column.searchable is same as(true) or column.searchable is same as(false) %}
             "searchable": {{ column.searchable|sg_datatables_bool_var }},
         {% endif %}

--- a/Resources/views/column/column.html.twig
+++ b/Resources/views/column/column.html.twig
@@ -23,6 +23,11 @@
         {% if column.width is not same as(null) %}
             "width": "{{ column.width }}",
         {% endif %}
+        {% block title %}
+            {% if column.title is not same as(null) %}
+                "title": "{{ column.title|raw }}",
+            {% endif %}
+        {% endblock %}
         {% if column.searchable is same as(true) or column.searchable is same as(false) %}
             "searchable": {{ column.searchable|sg_datatables_bool_var }},
         {% endif %}

--- a/Resources/views/datatable/columns.html.twig
+++ b/Resources/views/datatable/columns.html.twig
@@ -8,6 +8,8 @@
  #}
 "columns": [
     {% for column in sg_datatables_view.columnBuilder.columns %}
-        {% include column.getOptionsTemplate %}
+        {% if column.sentInResponse %}
+            {% include column.getOptionsTemplate %}
+        {% endif %}
     {% endfor %}
 ]

--- a/Resources/views/datatable/datatable_html.html.twig
+++ b/Resources/views/datatable/datatable_html.html.twig
@@ -20,31 +20,44 @@
             {% if 'head' == sg_datatables_view.options.individualFilteringPosition or 'both' == sg_datatables_view.options.individualFilteringPosition%}
                 <tr>
                     {% for column in sg_datatables_view.columnBuilder.columns %}
-                        <th>{{ column.title }}</th>
+                        {% if column.sentInResponse %}
+                            <th>{{ column.title }}</th>
+                        {% endif %}
                     {% endfor %}
                 </tr>
                 <tr id="sg-datatables-{{ sg_datatables_view.uniqueName }}-filterrow">
                     {% for column in sg_datatables_view.columnBuilder.columns %}
-                        <th>
-                            {% if column.searchable %}
-                                {{ sg_datatables_render_filter(sg_datatables_view, column, 'head') }}
-                            {% endif %}
-                        </th>
+                        {% if column.sentInResponse %}
+                            <th>
+                                {% if column.searchable %}
+                                    {{ sg_datatables_render_filter(sg_datatables_view, column, 'head') }}
+                                {% endif %}
+                            </th>
+                        {% endif %}
                     {% endfor %}
                 </tr>
             {% endif %}
         {% endif %}
+        <tr>
+            {% for column in sg_datatables_view.columnBuilder.columns %}
+                {% if column.sentInResponse %}
+                    <th>{{ column.title }}</th>
+                {% endif %}
+            {% endfor %}
+        </tr>
     </thead>
         {% if true == individual_filtering %}
             {% if 'foot' == sg_datatables_view.options.individualFilteringPosition or 'both' == sg_datatables_view.options.individualFilteringPosition%}
             <tfoot>
                     <tr>
                         {% for column in sg_datatables_view.columnBuilder.columns %}
-                            <td>
-                                {% if column.searchable %}
-                                    {{ sg_datatables_render_filter(sg_datatables_view, column, 'foot') }}
-                                {% endif %}
-                            </td>
+                            {% if column.sentInResponse %}
+                                <td>
+                                    {% if column.searchable %}
+                                        {{ sg_datatables_render_filter(sg_datatables_view, column, 'foot') }}
+                                    {% endif %}
+                                </td>
+                            {% endif %}
                         {% endfor %}
                     </tr>
                 </tfoot>

--- a/Resources/views/datatable/datatable_js.html.twig
+++ b/Resources/views/datatable/datatable_js.html.twig
@@ -50,7 +50,7 @@
 
         function postCreateDatatable(pipeline) {
             {% for column in sg_datatables_view.columnBuilder.columns %}
-                {% if column.renderPostCreateDatatableJsContent is not null %}
+                {% if column.sentInResponse and column.renderPostCreateDatatableJsContent is not null %}
                     {{ column.renderPostCreateDatatableJsContent|raw }}
                 {% endif %}
             {% endfor %}

--- a/Response/DatatableFormatter.php
+++ b/Response/DatatableFormatter.php
@@ -121,6 +121,12 @@ class DatatableFormatter
                 $column->renderCellContent($row);
             }
 
+            foreach ($columns as $column) {
+                if (!$column->getSentInResponse()) {
+                    unset($row[$column->getDql()]);
+                }
+            }
+
             $this->output['data'][] = $row;
         }
     }


### PR DESCRIPTION
Hi,
I added a column option `sent_in_response`. By default this option is set to `true`. But if you set it to `false`, it allows to get a field from the table, but without sending this field to the browser. This allows to access to this field in closures used in the options of other columns for instance.

The `visible` option isn't sufficient here, because it's only hide columns in browser, and user can show them. 