### PR TITLE
Removed SymfonyInsight label

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # SgDatatablesBundle
 
-[![SensioLabsInsight](https://insight.sensiolabs.com/projects/61803d08-17ab-4a69-ad13-6ec448762332/big.png)](https://insight.sensiolabs.com/projects/61803d08-17ab-4a69-ad13-6ec448762332)
-
 [![knpbundles.com](http://knpbundles.com/stwe/DatatablesBundle/badge)](http://knpbundles.com/stwe/DatatablesBundle)
 
 [![Build Status](https://travis-ci.org/stwe/DatatablesBundle.svg?branch=master)](https://travis-ci.org/stwe/DatatablesBundle)


### PR DESCRIPTION
This project hasn't been analyzed for 1,5 years, so it makes no sense to keep this badge. 