### PR TITLE
Drop PHP < 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ cache:
 matrix:
   fast_finish: true
   include:
-    - php: 5.5
-    - php: 5.6
-    - php: 7.0
     - php: 7.1
       env: DEPENDENCIES=beta
     - php: hhvm
@@ -26,8 +23,7 @@ before_install:
   - if [ "$DEPENDENCIES" = "beta" ]; then composer config minimum-stability beta; fi;  
   - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/framework-bundle=$SYMFONY_VERSION; fi
   - if [ "$DEPENDENCIES" = "dev" ]; then perl -pi -e 's/^}$/,"minimum-stability":"dev"}/' composer.json; fi;
-  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "5." ]]; then composer require --dev "phpunit/phpunit=4.8.*"; fi
-  - if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." || ${TRAVIS_PHP_VERSION:0:2} == "hh" ]]; then composer require --dev "phpunit/phpunit=5.7.*"; fi
+  - composer require --dev "phpunit/phpunit=5.7.*"
 
 install: composer update --prefer-dist --no-interaction $COMPOSER_FLAGS
 

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "issues": "https://github.com/stwe/DatatablesBundle/issues"
     },
     "require": {
-        "php": ">=5.5.9",
+        "php": ">=7.1",
         "symfony/framework-bundle": "^3.0|^4.0",
         "doctrine/orm": "^2.5",
         "symfony/options-resolver": "^3.0|^4.0",


### PR DESCRIPTION
PHP 5.4, 5.5 and 7.0 are End Of Life (EOL) now, 5.6 will be in a month.

Developers working with PHP 5 or PHP 7.0 should be banned from the community as soon as possible ;).