### PR TITLE
Fix POST AJAX requests

### DIFF
--- a/Resources/views/datatable/ajax.html.twig
+++ b/Resources/views/datatable/ajax.html.twig
@@ -10,7 +10,7 @@
     {% if sg_datatables_view.ajax.url is not same as(null) %}
         "url": "{{ sg_datatables_view.ajax.url|raw }}",
     {% endif %}
-    "type": "{{ sg_datatables_view.ajax.type }}",
+    "method": "{{ sg_datatables_view.ajax.type }}",
     {% if sg_datatables_view.ajax.data is not same as(null) %}
         "data": {{ sg_datatables_view.ajax.data|raw }},
     {% endif %}


### PR DESCRIPTION
pipeline.js is accepting request type (GET/POST) as a 'method' parameter, not 'type'