### PR TITLE
Fixing DateTime::__construct() issue for french local

### DIFF
--- a/Resources/translations/messages.fr.yml
+++ b/Resources/translations/messages.fr.yml
@@ -9,4 +9,4 @@ sg:
         daterange:
             apply: "Appliquer"
             cancel: "Annuler"
-            format: "DD/MM/YYYY"
+            format: "YYYY-MM-DD"


### PR DESCRIPTION
Fix of #722 
Date range is not working in fr local right now.
This is probably not the best way, but because we use daterange picker to select date range, for me it's not a big issue to have date in english format.