### PR TITLE
Added null test for PHP > 7.1

### DIFF
--- a/Datatable/Column/DateTimeColumn.php
+++ b/Datatable/Column/DateTimeColumn.php
@@ -88,7 +88,7 @@ class DateTimeColumn extends AbstractColumn
         if ($this->accessor->isReadable($row, $path)) {
             $entries = $this->accessor->getValue($row, $path);
 
-            if (count($entries) > 0) {
+            if (!is_null($entries) && count($entries) > 0) {
                 foreach ($entries as $key => $entry) {
                     $currentPath = $path . '[' . $key . ']' . $value;
                     $currentObjectPath = Helper::getPropertyPathObjectNotation($path, $key, $value);


### PR DESCRIPTION
Fixes the problem reported in #812 and #883

When the array is null, the count finction in PHP 7.2 an hight stop working. With the null check in the if clause, the problem is solved and run like it should.