### PR TITLE
Fix unknown property "method" on Route annotation

### DIFF
--- a/Controller/DatatableController.php
+++ b/Controller/DatatableController.php
@@ -38,7 +38,7 @@ class DatatableController extends Controller
      *
      * @param Request $request
      *
-     * @Route("/datatables/edit/field", method={"POST"}, name="sg_datatables_edit")
+     * @Route("/datatables/edit/field", methods={"POST"}, name="sg_datatables_edit")
      *
      * @return Response
      * @throws Exception


### PR DESCRIPTION
According to Symfony documentation, right property name for specifying methods is "methods", not "method". It also throws me an exception:

> An exception has been thrown during the rendering of a template ("Unknown property "method" on annotation "Symfony\Component\Routing\Annotation\Route" in .../vendor/sg/datatablesbundle/Controller/ (which is being imported from ".../config/routes/sg_datatables_bundle.yaml"). Make sure annotations are installed and enabled.").