### PR TITLE
Ability to use multiple keywords in global search

### DIFF
--- a/Datatable/Options.php
+++ b/Datatable/Options.php
@@ -299,7 +299,7 @@ class Options
         $resolver->setAllowedTypes('global_search_type', 'string');
 
         $resolver->setAllowedValues('individual_filtering_position', ['head', 'foot', 'both']);
-        $resolver->setAllowedValues('global_search_type', ['like', '%like', 'like%', 'notLike', 'eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'in', 'notIn', 'isNull', 'isNotNull']);
+        $resolver->setAllowedValues('global_search_type', ['like', 'keywords_string', '%like', 'like%', 'notLike', 'eq', 'neq', 'lt', 'lte', 'gt', 'gte', 'in', 'notIn', 'isNull', 'isNotNull']);
 
         return $this;
     }

--- a/Resources/doc/options.md
+++ b/Resources/doc/options.md
@@ -26,7 +26,7 @@ With 'null' initialized options uses the default value of the DataTables plugin.
 | individual_filtering          | bool               | false     | Enable or disable individual filtering. |
 | individual_filtering_position | string             | 'head'    | Position of individual search filter ('head', 'foot' or 'both'). |
 | search_in_non_visible_columns | bool               | false     | Determines whether to search in non-visible columns. |
-| global_search_type            | string             | 'like'    | The global search type (example: 'eq'). |
+| global_search_type            | string             | 'like'    | The global search type (example: 'eq'). Use 'keywords_string' to search by multiple keywords. |
 
 ``` php
 class PostDatatable extends AbstractDatatable


### PR DESCRIPTION
I have found that is was very frustrating to to be able to use multiple keywords in the global search filters.

For example, we had a customer field in our organisation with values such as "Daniel Brian Brown" and when people were entering "Daniel Brown" in the global search, it would not come up.

Therefore, I have added a new 'keywords_string' value to the 'global_search_type' option. It makes datatables much more flexible when using the global search filter to find information.

I hope you like it and you can merge it soon !