### PR TITLE
Add doctrine time support for datetime column when using inplace editor

### DIFF
--- a/Controller/DatatableController.php
+++ b/Controller/DatatableController.php
@@ -125,6 +125,7 @@ class DatatableController extends Controller
     {
         switch ($originalTypeOfField) {
             case Type::DATETIME:
+            case Type::TIME:
                 $value = new DateTime($value);
                 break;
             case Type::BOOLEAN:


### PR DESCRIPTION
This PR add support for doctrine time type in Datatable and prevent error when using time with inplace editor.

Fix #905 