### PR TITLE
[IMP] filtering: Prevent duplicate search triggered on text input change

### DIFF
--- a/Resources/views/datatable/search.js.twig
+++ b/Resources/views/datatable/search.js.twig
@@ -37,7 +37,7 @@ var search = $.fn.dataTable.util.throttle(
         options.searchDelay
 );
 
-$(selector + '-filterrow').find("input.sg-datatables-individual-filtering").on("keyup change", search);
+$(selector + '-filterrow').find("input.sg-datatables-individual-filtering").on("keyup input", search);
 
 $(selector + '-filterrow').find("select.sg-datatables-individual-filtering").on("keyup change", function(event) {
     var searchValue = $(this).val();


### PR DESCRIPTION
This is a low priority old bug that I was trying to track down when having a little bit of time. 

Use case:
* datatable with text input individual filtering and action links on each row
* user filters one column by writing some text in the text input > search is triggered
* the filtered result shows up successfully
* user clicks on the action link from one of the filteres rows
* another serarch is triggered, same as the last one, from the "change" event behaviour which on text inputs runs after the input loses focus and the value has changed

Fix [search.js.twig](https://github.com/stwe/DatatablesBundle/blob/master/Resources/views/datatable/search.js.twig)
`$(selector + '-filterrow').find("input.sg-datatables-individual-filtering").on("keyup change", search);
`
`$(selector + '-filterrow').find("input.sg-datatables-individual-filtering").on("keyup input", search);
`

By switching the "change" event with the "input" event, mobile users would also experience the same behaviour as desktop users where search trigger will be evaluated after each button click on the virtual keyboard.