### PR TITLE
[IMP] filtering: Prevent search triggered on tab keyup

### DIFF
--- a/Resources/views/datatable/search.js.twig
+++ b/Resources/views/datatable/search.js.twig
@@ -24,7 +24,8 @@ var search = $.fn.dataTable.util.throttle(
                         event.keyCode == 40 ||
                         event.keyCode == 16 ||
                         event.keyCode == 17 ||
-                        event.keyCode == 18
+                        event.keyCode == 18 ||
+                        event.keyCode == 9
                 )
                     return;
             }


### PR DESCRIPTION
Tab key is usually used to jump between inputs and it should not be triggering the keyup search event as it will not change the search result.