### PR TITLE
Correction adding like% and %like in filter

### DIFF
--- a/Datatable/Filter/AbstractFilter.php
+++ b/Datatable/Filter/AbstractFilter.php
@@ -304,6 +304,8 @@ abstract class AbstractFilter implements FilterInterface
         ) {
             switch ($searchType) {
                 case 'like':
+                case '%like':
+                case 'like%':
                     $searchType = 'eq';
 
                     break;


### PR DESCRIPTION
Pushing https://github.com/stwe/DatatablesBundle/pull/870 has made reappear the issue https://github.com/doctrine/doctrine2/issues/6363.

I have reproduce trying something like that:

`    $this->columnBuilder->add('structurePath', Column::class, array(

    'title' => 'structure path',
        'searchable' => true,
        'dql' => '(SELECT GROUP_CONCAT({s}.label SEPARATOR \' \') FROM '.Structure::class.' {s} WHERE {s}.lft <= structure.lft and {s}.rgt >= structure.rgt and {s}.root = structure.root)',
        'type_of_field' => 'string',
        'filter' => array(TextFilter::class, array(
            'search_type' => 'like%',
        ))
    ));
` 
So I suggest this correction according to the existing solution.
