### PR TITLE
Added aliases for Symfony4 service autowiring

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -32,3 +32,11 @@ services:
             - '@router'
             - '@doctrine.orm.entity_manager'
             - '@twig'
+
+    Sg\DatatablesBundle\Response\DatatableResponse:
+        alias: sg_datatables.response
+        public: false
+
+    Sg\DatatablesBundle\Datatable\DatatableFactory:
+        alias: sg_datatables.factory
+        public: false


### PR DESCRIPTION
Hello,

This PR adds some aliases so Symfony4 autowiring works out of the box.
Still it keep old service names, so there's no BC break.

It fixes #857

Example of autowiring :
```php
class MyController extends AbstractController
{
    /**
     * @Route("/test", name="test_index")
     */
    public function index(DatatableFactory $factory, DatatableResponse $datatableResponse, Request $request)
    {
       $datatable = $factory->create(PostDatatable::class);
        $datatable->buildDatatable();

        if ($request->isXmlHttpRequest()) {
            $datatableResponse->setDatatable($datatable);
            $datatableResponse->getDatatableQueryBuilder();

            return $datatableResponse->getResponse();
        }

      return $this->render('post/index.html.twig', array(
            'datatable' => $datatable,
      ));
    }
}

```