### PR TITLE
[ADD] extension: FixedHeader extension

### DIFF
--- a/Datatable/Extension/FixedHeader.php
+++ b/Datatable/Extension/FixedHeader.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * This file is part of the SgDatatablesBundle package.
+ *
+ * (c) stwe <https://github.com/stwe/DatatablesBundle>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Sg\DatatablesBundle\Datatable\Extension;
+
+use Exception;
+use Sg\DatatablesBundle\Datatable\OptionsTrait;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class FixedHeader
+{
+    use OptionsTrait;
+
+    //-------------------------------------------------
+    // DataTables - FixedHeader Extension
+    //-------------------------------------------------
+
+    /**
+     * Enable / disable fixed footer
+     * Enable the fixing of the table footer (true) or disable (false).
+     * Required option.
+     *
+     * @var bool
+     */
+    protected $footer;
+
+    /**
+     * Offset the table's fixed footer
+     * Set the offset (in pixels) of the footer element's offset for the scrolling calculations.
+     * Optional.
+     *
+     * @var int
+     */
+    protected $footerOffset;
+
+    /**
+     * Enable / disable fixed header
+     * Enable the fixing of the table header (true) or disable (false).
+     * Optional.
+     *
+     * @var bool
+     */
+    protected $header;
+
+    /**
+     * Offset the table's fixed header
+     * Set the offset (in pixels) of the header element's offset for the scrolling calculations.
+     * Optional.
+     *
+     * @var int
+     */
+    protected $headerOffset;
+
+    public function __construct()
+    {
+        $this->initOptions();
+    }
+
+    //-------------------------------------------------
+    // Options
+    //-------------------------------------------------
+
+    /**
+     * @return $this
+     */
+    public function configureOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefined('footer');
+        $resolver->setDefined('footer_offset');
+        $resolver->setDefined('header');
+        $resolver->setDefined('header_offset');
+
+        $resolver->setAllowedTypes('footer', ['bool']);
+        $resolver->setAllowedTypes('footer_offset', ['int']);
+        $resolver->setAllowedTypes('header', ['bool']);
+        $resolver->setAllowedTypes('header_offset', ['int']);
+
+        return $this;
+    }
+
+    //-------------------------------------------------
+    // Getters && Setters
+    //-------------------------------------------------
+
+    /**
+     * @return bool
+     */
+    public function getFooter(): bool
+    {
+        return $this->footer;
+    }
+
+    /**
+     * @param bool $footer
+     * @return FixedHeader
+     */
+    public function setFooter(bool $footer): FixedHeader
+    {
+        $this->footer = $footer;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getFooterOffset(): int
+    {
+        return $this->footerOffset;
+    }
+
+    /**
+     * @param int $footerOffset
+     * @return FixedHeader
+     */
+    public function setFooterOffset(int $footerOffset): FixedHeader
+    {
+        $this->footerOffset = $footerOffset;
+
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getHeader(): bool
+    {
+        return $this->header;
+    }
+
+    /**
+     * @param bool $header
+     * @return FixedHeader
+     */
+    public function setHeader(bool $header): FixedHeader
+    {
+        $this->header = $header;
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getHeaderOffset(): int
+    {
+        return $this->headerOffset;
+    }
+
+    /**
+     * @param int $headerOffset
+     * @return FixedHeader
+     */
+    public function setHeaderOffset(int $headerOffset): FixedHeader
+    {
+        $this->headerOffset = $headerOffset;
+
+        return $this;
+    }
+}

--- a/Datatable/Extensions.php
+++ b/Datatable/Extensions.php
@@ -15,6 +15,7 @@ use Sg\DatatablesBundle\Datatable\Extension\Buttons;
 use Sg\DatatablesBundle\Datatable\Extension\Responsive;
 use Sg\DatatablesBundle\Datatable\Extension\RowGroup;
 use Sg\DatatablesBundle\Datatable\Extension\Select;
+use Sg\DatatablesBundle\Datatable\Extension\FixedHeader;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class Extensions
@@ -60,6 +61,15 @@ class Extensions
      */
     protected $rowGroup;
 
+    /**
+     * The FixedHeader Extension.
+     * Shows table's header and / or footer fixed to the top or bottom of the scrolling window.
+     * Default: null.
+     *
+     * @var array|bool|RowGroup|null
+     */
+    protected $fixedHeader;
+
     public function __construct()
     {
         $this->initOptions();
@@ -79,12 +89,14 @@ class Extensions
             'responsive' => null,
             'select' => null,
             'row_group' => null,
+            'fixed_header' => null,
         ]);
 
         $resolver->setAllowedTypes('buttons', ['null', 'array', 'bool']);
         $resolver->setAllowedTypes('responsive', ['null', 'array', 'bool']);
         $resolver->setAllowedTypes('select', ['null', 'array', 'bool']);
         $resolver->setAllowedTypes('row_group', ['null', 'array', 'bool']);
+        $resolver->setAllowedTypes('fixed_header', ['null', 'array', 'bool']);
 
         return $this;
     }
@@ -190,6 +202,34 @@ class Extensions
             $this->rowGroup = $newRowGroup->set($rowGroup);
         } else {
             $this->rowGroup = $rowGroup;
+        }
+
+        return $this;
+    }
+
+
+
+    /**
+     * @return array|bool|FixedHeader|null
+     */
+    public function getFixedHeader()
+    {
+        return $this->fixedHeader;
+    }
+
+    /**
+     * @param array|bool|null $fixedHeader
+     *
+     * @return $this
+     * @throws \Exception
+     */
+    public function setFixedHeader($fixedHeader)
+    {
+        if (\is_array($fixedHeader)) {
+            $newFixedHeader = new FixedHeader();
+            $this->fixedHeader = $newFixedHeader->set($fixedHeader);
+        } else {
+            $this->fixedHeader = $fixedHeader;
         }
 
         return $this;

--- a/Resources/doc/extensions.md
+++ b/Resources/doc/extensions.md
@@ -4,6 +4,7 @@
 2. [Responsive](#2-responsive)
 3. [Select](#3-select)
 4. [RowGroup](#4-rowgroup)
+5. [FixedHeader](#5-fixedheader)
 
 ## 1. Buttons
 
@@ -359,4 +360,65 @@ With the RowGroup class you can set the following options, for details see the [
 | endClassName      | string or null  | null  | Set the class name to be used for the grouping end rows |
 | endRender         | array or null   | null  | Provide a function that can be used to control the data shown in the end grouping row. |
 | startRender       | array or null   | null  | Provide a function that can be used to control the data shown in the start grouping row. |
+___
+
+## 5. FixedHeader
+
+**Be sure to install the [FixedHeader Extension](https://datatables.net/extensions/fixedheader/) before using.**
+
+### Template
+
+@SgDatatables/datatable/extensions.html.twig
+
+### Initialisation
+
+#### The easiest way
+
+The easiest way is to add `fixed_header` to your extensions options with the header/footer option defined respectively with `header` and `footer`.
+
+``` php
+public function buildDatatable(array $options = array())
+{
+    // ...
+
+    $this->extensions->set(array(
+        'fixed_header' => array(
+            'header' => true
+        ),
+    ));
+    
+    // ...
+}
+```
+
+#### Advanced example
+
+This example adds an offset to the header:
+
+``` php
+public function buildDatatable(array $options = array())
+{
+    // ...
+
+    $this->extensions->set(array(
+        'fixed_header' => array(
+            'header' => true,
+            'header_offset' => 50,
+        ),
+    ));
+    
+    // ...
+}
+```
+
+### FixedHeader class options
+
+With the FixedHeader class you can set the following options, for details see the [Plugin documentation](https://datatables.net/reference/option/#fixedheader).
+
+| Option    | Type            | Default |  Description                       |
+|-----------|-----------------|---------|------------------------------------|
+| footer           | boolean         | false  | Enable the fixing of the table footer (`true`) or disable (`false`) |
+| footerOffset     | integer         | 0      | Set the offset (in pixels) of the footer element's offset for the scrolling calculations |
+| header           | boolean         | false  | Enable the fixing of the table header (`true`) or disable (`false`) |
+| headerOffset     | integer         | 0      | Set the offset (in pixels) of the header element's offset for the scrolling calculations |
 ___

--- a/Resources/views/datatable/extensions.html.twig
+++ b/Resources/views/datatable/extensions.html.twig
@@ -136,3 +136,21 @@
     {% endif %}
     },
 {% endif %}
+
+{# FixedHeader Extension #}
+{% if sg_datatables_view.extensions.fixedHeader is not same as(null) %}
+    fixedHeader: {
+    {% if sg_datatables_view.extensions.fixedHeader.header is defined and sg_datatables_view.extensions.fixedHeader.header is same as(true) %}
+        header: true,
+    {% endif %}
+    {% if sg_datatables_view.extensions.fixedHeader.headerOffset is defined and sg_datatables_view.extensions.fixedHeader.headerOffset is not same as(null) %}
+        headerOffset: '{{ sg_datatables_view.extensions.fixedHeader.headerOffset }}',
+    {% endif %}
+    {% if sg_datatables_view.extensions.fixedHeader.footer is defined and sg_datatables_view.extensions.fixedHeader.footer is same as(true) %}
+        footer: true,
+    {% endif %}
+    {% if sg_datatables_view.extensions.fixedHeader.footerOffset is defined and sg_datatables_view.extensions.fixedHeader.footerOffset is not same as(null) %}
+        footerOffset: '{{ sg_datatables_view.extensions.fixedHeader.footerOffset }}',
+    {% endif %}
+    },
+{% endif %}


### PR DESCRIPTION
Implemented the FixedHeader extension which has the ability to shows table's header and / or footer fixed to the top or bottom of the scrolling window.