### PR TITLE
[FIX] extension: RowGroup use end renderer argument variable

### DIFF
--- a/Datatable/Extension/RowGroup.php
+++ b/Datatable/Extension/RowGroup.php
@@ -207,13 +207,13 @@ class RowGroup
      */
     public function setEndRender($endRender)
     {
-        if (false === \array_key_exists('template', $startRender)) {
+        if (false === \array_key_exists('template', $endRender)) {
             throw new Exception(
                 'RowGroup::setEndRender(): The "template" option is required.'
             );
         }
 
-        foreach ($startRender as $key => $value) {
+        foreach ($endRender as $key => $value) {
             if (false === \in_array($key, ['template', 'vars'], true)) {
                 throw new Exception(
                     "RowGroup::setEndRender(): {$key} is not a valid option."


### PR DESCRIPTION
Fixes the use of the undefined `$startRender` variable by using the original argument variable `$endRender`.