### PR TITLE
refs #976: fixed Datatable name validation

### DIFF
--- a/Datatable/AbstractDatatable.php
+++ b/Datatable/AbstractDatatable.php
@@ -12,7 +12,7 @@
 namespace Sg\DatatablesBundle\Datatable;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Exception;
+use LogicException;
 use Sg\DatatablesBundle\Datatable\Column\ColumnBuilder;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\PropertyAccess\PropertyAccessor;
@@ -147,7 +147,7 @@ abstract class AbstractDatatable implements DatatableInterface
     protected static $uniqueCounter = [];
 
     /**
-     * @throws Exception
+     * @throws LogicException
      */
     public function __construct(
         AuthorizationCheckerInterface $authorizationChecker,
@@ -313,12 +313,13 @@ abstract class AbstractDatatable implements DatatableInterface
     /**
      * Checks the name only contains letters, numbers, underscores or dashes.
      *
-     * @throws Exception
+     * @throws LogicException
      */
     private function validateName()
     {
-        if (1 !== preg_match(self::NAME_REGEX, $this->getName())) {
-            throw new Exception('AbstractDatatable::validateName(): The result of the getName method can only contain letters, numbers, underscore and dashes.');
+        $name = $this->getName();
+        if (1 !== preg_match(self::NAME_REGEX, $name)) {
+            throw new LogicException(sprintf('AbstractDatatable::validateName(): "%s" is invalid Datatable Name. Name can only contain letters, numbers, underscore and dashes.', $name));
         }
     }
 }

--- a/Datatable/DatatableInterface.php
+++ b/Datatable/DatatableInterface.php
@@ -19,7 +19,7 @@ use Sg\DatatablesBundle\Datatable\Column\ColumnBuilder;
  */
 interface DatatableInterface
 {
-    const NAME_REGEX = '/[a-zA-Z0-9\-\_]+/';
+    const NAME_REGEX = '/^[a-zA-Z0-9\-\_]+$/';
 
     /**
      * Builds the datatable.

--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -359,6 +359,11 @@ class PostDatatable extends AbstractDatatable
 }
 ```
 
+**Important:**
+When declaring datatable "by hand" as extending `AbstractDatatable` class watch out for datatable name as returned from
+`getName()` method. Valid datatable name may contains only letters ([a-zA-Z]), digits (0-9), dashes (-) and underscores 
+(_). Putting any other character in name will cause `\LogicException` to be thrown.
+
 ### Step 2: (Optional) Registering your Datatable as a Service
 
 ``` yaml


### PR DESCRIPTION
- added test for invalid name validation
- changed thrown exception from `\Exception` to more specific `\LogicException`
- updated documentation

As validation worked only if datatable name was composed of only invalid characters exception type change might not be considered backward incompatible.