### PR TITLE
Allow string search in json type fields

### DIFF
--- a/Datatable/Filter/AbstractFilter.php
+++ b/Datatable/Filter/AbstractFilter.php
@@ -296,7 +296,7 @@ abstract class AbstractFilter implements FilterInterface
         // Only StringExpression can be searched with LIKE (https://github.com/doctrine/doctrine2/issues/6363)
         if (
             // Not a StringExpression
-            ! preg_match('/text|string|date|time|array|json_array|simple_array/', $searchTypeOfField)
+            ! preg_match('/text|string|date|time|array|json|json_array|simple_array/', $searchTypeOfField)
             // Subqueries can't be search with LIKE
             || preg_match('/SELECT.+FROM.+/is', $searchField)
             // CASE WHEN can't be search with LIKE


### PR DESCRIPTION
The json_array type is deprecated, so I've added the json type:
https://www.doctrine-project.org/projects/doctrine-dbal/en/2.7/reference/types.html#json